### PR TITLE
add marker to differentiate the hash of a leaf from of an internal node

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -78,6 +78,15 @@ func ParseNode(serialized []byte, depth byte, comm []byte) (VerkleNode, error) {
 		return ln, nil
 	case internalRLPType:
 		return CreateInternalNode(serialized[1:33], serialized[33:], depth, comm)
+	case hashedLeafRLPType:
+		ln := &HashedNode{
+			stem:       serialized[1:32],
+			commitment: new(Point),
+			hash:       new(Fr),
+		}
+		ln.commitment.SetBytes(serialized[32:])
+		ln.hash.SetBytes(comm)
+		return ln, nil
 	default:
 		return nil, ErrInvalidNodeEncoding
 	}

--- a/hashednode.go
+++ b/hashednode.go
@@ -33,6 +33,7 @@ import (
 type HashedNode struct {
 	hash       *Fr
 	commitment *Point
+	stem       []byte
 }
 
 func (*HashedNode) Insert([]byte, []byte, NodeResolverFn) error {
@@ -73,6 +74,10 @@ func (n *HashedNode) Copy() VerkleNode {
 	}
 	if n.commitment != nil {
 		CopyPoint(h.commitment, n.commitment)
+	}
+	if n.stem != nil {
+		h.stem = make([]byte, len(n.stem))
+		copy(h.stem, n.stem)
 	}
 
 	return h

--- a/hashednode.go
+++ b/hashednode.go
@@ -60,8 +60,17 @@ func (*HashedNode) GetProofItems(keylist) (*ProofElements, []byte, [][]byte) {
 	panic("can not get the full path, and there is no proof of absence")
 }
 
-func (*HashedNode) Serialize() ([]byte, error) {
-	return nil, errSerializeHashedNode
+func (n *HashedNode) Serialize() ([]byte, error) {
+	if len(n.stem) == 0 {
+		return nil, errSerializeHashedNode
+	}
+
+	ser := make([]byte, 1, 1+31+32)
+	ser[0] = hashedLeafRLPType
+	ser = append(ser, n.stem...)
+	serComm := n.commitment.Bytes()
+	ser = append(ser, serComm[:]...)
+	return ser, nil
 }
 
 func (n *HashedNode) Copy() VerkleNode {


### PR DESCRIPTION
Necessary for #229

This is useful because it makes it possible to diff-insert into `LeafNodes` without actually loading them in the tree. This has two consequences:

* No need to store the `LeafNodes` in the DB - they are considered write-only
* Save time during conversion because a vast majority of the nodes aren't saved to the database