### PR TITLE
TreeFromProof test hardening

### DIFF
--- a/proof_test.go
+++ b/proof_test.go
@@ -1147,3 +1147,102 @@ func TestGenerateProofWithOnlyAbsentKeys(t *testing.T) {
 		}
 	}
 }
+
+func TestDoubleProofOfAbsence(t *testing.T) {
+	t.Parallel()
+
+	root := New()
+
+	// Insert some keys.
+	key11, _ := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000001")
+	key12, _ := hex.DecodeString("0003000000000000000000000000000000000000000000000000000000000001")
+
+	if err := root.Insert(key11, fourtyKeyTest, nil); err != nil {
+		t.Fatalf("could not insert key: %v", err)
+	}
+	if err := root.Insert(key12, fourtyKeyTest, nil); err != nil {
+		t.Fatalf("could not insert key: %v", err)
+	}
+
+	// Try to prove to different stems that end up in the same LeafNode without any other proof of presence
+	// in that leaf node. i.e: two proof of absence in the same leaf node with no proof of presence.
+	key2, _ := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000100")
+	key3, _ := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000200")
+	proof, _, _, _, _ := MakeVerkleMultiProof(root, nil, keylist{key2, key3}, nil)
+
+	serialized, statediff, err := SerializeProof(proof)
+	if err != nil {
+		t.Fatalf("could not serialize proof: %v", err)
+	}
+
+	dproof, err := DeserializeProof(serialized, statediff)
+	if err != nil {
+		t.Fatalf("error deserializing proof: %v", err)
+	}
+
+	droot, err := PreStateTreeFromProof(dproof, root.Commit())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !droot.Commit().Equal(root.Commit()) {
+		t.Fatal("differing root commitments")
+	}
+
+	// Depite we have two proof of absences for different steams, we should only have one
+	// stem in `others`. i.e: we only need one for both steams.
+	if len(proof.PoaStems) != 1 {
+		t.Fatalf("invalid number of proof-of-absence stems: %d", len(proof.PoaStems))
+	}
+
+	// We need one extension status for each stem.
+	if len(proof.ExtStatus) != 2 {
+		t.Fatalf("invalid number of extension status: %d", len(proof.PoaStems))
+	}
+}
+
+func TestProveAbsenceInEmptyHalf(t *testing.T) {
+	t.Parallel()
+
+	root := New()
+
+	key1, _ := hex.DecodeString("00000000000000000000000000000000000000000000000000000000000000FF")
+
+	if err := root.Insert(key1, fourtyKeyTest, nil); err != nil {
+		t.Fatalf("could not insert key: %v", err)
+	}
+	if err := root.Insert(key1, fourtyKeyTest, nil); err != nil {
+		t.Fatalf("could not insert key: %v", err)
+	}
+
+	key2, _ := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000100")
+	key3, _ := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000000")
+	proof, _, _, _, _ := MakeVerkleMultiProof(root, nil, keylist{key2, key3}, nil)
+
+	serialized, statediff, err := SerializeProof(proof)
+	if err != nil {
+		t.Fatalf("could not serialize proof: %v", err)
+	}
+
+	dproof, err := DeserializeProof(serialized, statediff)
+	if err != nil {
+		t.Fatalf("error deserializing proof: %v", err)
+	}
+
+	droot, err := PreStateTreeFromProof(dproof, root.Commit())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !droot.Commit().Equal(root.Commit()) {
+		t.Fatal("differing root commitments")
+	}
+
+	if len(proof.PoaStems) != 0 {
+		t.Fatalf("invalid number of proof-of-absence stems: %d", len(proof.PoaStems))
+	}
+
+	if len(proof.ExtStatus) != 2 {
+		t.Fatalf("invalid number of extension status: %d", len(proof.ExtStatus))
+	}
+}


### PR DESCRIPTION
This PR adds more test coverage for `PreStateTreeFromProof(...)`.

The diff is very messy, so I recommend some "split view" maybe.