### PR TITLE
test: add random tree operation tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/crate-crypto/go-ipa v0.0.0-20231025140028-3c0104f4b233
+	github.com/davecgh/go-spew v1.1.1
 	golang.org/x/sync v0.1.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,7 @@ github.com/consensys/gnark-crypto v0.12.1/go.mod h1:v2Gy7L/4ZRosZ7Ivs+9SfUDr0f5U
 github.com/crate-crypto/go-ipa v0.0.0-20231025140028-3c0104f4b233 h1:d28BXYi+wUpz1KBmiF9bWrjEMacUEREV6MBi2ODnrfQ=
 github.com/crate-crypto/go-ipa v0.0.0-20231025140028-3c0104f4b233/go.mod h1:geZJZH3SzKCqnz5VT0q/DyIG/tvu/dZk+VIfXicupJs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
 github.com/mmcloughlin/addchain v0.4.0 h1:SobOdjm2xLj1KkXN5/n0xTIWyZA2+s99UCY1iPfkHRY=

--- a/proof_test.go
+++ b/proof_test.go
@@ -36,6 +36,19 @@ import (
 	"github.com/crate-crypto/go-ipa/common"
 )
 
+func TestProofEmptyTree(t *testing.T) {
+	t.Parallel()
+
+	root := New()
+	root.Commit()
+
+	proof, cis, zis, yis, _ := MakeVerkleMultiProof(root, nil, [][]byte{ffx32KeyTest}, nil)
+	cfg := GetConfig()
+	if ok, err := VerifyVerkleProof(proof, cis, zis, yis, cfg); !ok || err != nil {
+		t.Fatalf("could not verify verkle proof: %s", ToDot(root))
+	}
+}
+
 func TestProofVerifyTwoLeaves(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This PR adds a random tree operation test case, referring [Geth's TestRandom implementation](https://github.com/ethereum/go-ethereum/blob/master/trie/trie_test.go#L616-L623). Minor modifications are as follows:
- only 32 bytes of random keys are created
- omitting `opItercheckhash` and `opNodeDiff`, can add them once the functionalities are ready 