### PR TITLE
fix: typo of NewLeafNodeWithNoComms( )

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -309,7 +309,7 @@ func NewLeafNode(stem []byte, values [][]byte) (*LeafNode, error) {
 	}, nil
 }
 
-// NewLeafNodeWithNoComms create a leaf node but does compute its
+// NewLeafNodeWithNoComms create a leaf node but does not compute its
 // commitments. The created node's commitments are intended to be
 // initialized with `SetTrustedBytes` in a deserialization context.
 func NewLeafNodeWithNoComms(stem []byte, values [][]byte) *LeafNode {


### PR DESCRIPTION
Fixed the typo in https://github.com/ethereum/go-verkle/blob/master/tree.go#L312
(excuse me for closing the pr earlier)