### PR TITLE
refactor(tree): use const and type declaration

### DIFF
--- a/config.go
+++ b/config.go
@@ -30,6 +30,7 @@ import (
 )
 
 const (
+	KeySize            = 32
 	LeafValueSize      = 32
 	NodeWidth          = 256
 	NodeBitWidth  byte = 8

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ const (
 )
 
 func equalPaths(key1, key2 []byte) bool {
-	return bytes.Equal(key1[:StemSize], key2[:StemSize])
+	return bytes.Equal(KeyToStem(key1), KeyToStem(key2))
 }
 
 // offset2key extracts the n bits of a key that correspond to the

--- a/conversion.go
+++ b/conversion.go
@@ -13,7 +13,7 @@ import (
 
 // BatchNewLeafNodeData is a struct that contains the data needed to create a new leaf node.
 type BatchNewLeafNodeData struct {
-	Stem   []byte
+	Stem   Stem
 	Values map[byte][]byte
 }
 

--- a/debug.go
+++ b/debug.go
@@ -36,7 +36,7 @@ type (
 	}
 
 	ExportableLeafNode struct {
-		Stem   []byte   `json:"stem"`
+		Stem   Stem     `json:"stem"`
 		Values [][]byte `json:"values"`
 
 		C  [32]byte `json:"commitment"`

--- a/empty.go
+++ b/empty.go
@@ -53,7 +53,7 @@ func (Empty) Commitment() *Point {
 	return &id
 }
 
-func (Empty) GetProofItems(keylist, NodeResolverFn) (*ProofElements, []byte, [][]byte, error) {
+func (Empty) GetProofItems(keylist, NodeResolverFn) (*ProofElements, []byte, []Stem, error) {
 	return nil, nil, nil, errors.New("trying to produce a commitment for an empty subtree")
 }
 

--- a/encoding.go
+++ b/encoding.go
@@ -94,7 +94,7 @@ func parseLeafNode(serialized []byte, depth byte) (VerkleNode, error) {
 	for i := 0; i < NodeWidth; i++ {
 		if bit(bitlist, i) {
 			if offset+LeafValueSize > len(serialized) {
-				return nil, fmt.Errorf("verkle payload is too short, need at least %d and only have %d, payload = %x (%w)", offset+32, len(serialized), serialized, errSerializedPayloadTooShort)
+				return nil, fmt.Errorf("verkle payload is too short, need at least %d and only have %d, payload = %x (%w)", offset+LeafValueSize, len(serialized), serialized, errSerializedPayloadTooShort)
 			}
 			values[i] = serialized[offset : offset+LeafValueSize]
 			offset += LeafValueSize

--- a/hashednode.go
+++ b/hashednode.go
@@ -58,7 +58,7 @@ func (HashedNode) Commitment() *Point {
 	panic("can not get commitment of a hash node")
 }
 
-func (HashedNode) GetProofItems(keylist, NodeResolverFn) (*ProofElements, []byte, [][]byte, error) {
+func (HashedNode) GetProofItems(keylist, NodeResolverFn) (*ProofElements, []byte, []Stem, error) {
 	return nil, nil, nil, errors.New("can not get the full path, and there is no proof of absence")
 }
 

--- a/ipa.go
+++ b/ipa.go
@@ -39,10 +39,10 @@ type (
 )
 
 func FromLEBytes(fr *Fr, data []byte) error {
-	if len(data) > 32 {
+	if len(data) > LeafValueSize {
 		return errors.New("data is too long")
 	}
-	var aligned [32]byte
+	var aligned [LeafValueSize]byte
 	copy(aligned[:], data)
 	fr.SetBytesLE(aligned[:])
 	return nil

--- a/proof_json.go
+++ b/proof_json.go
@@ -170,7 +170,7 @@ func (vp *VerkleProof) UnmarshalJSON(data []byte) error {
 	}
 	copy(vp.D[:], currentValueBytes)
 
-	vp.OtherStems = make([][31]byte, len(aux.OtherStems))
+	vp.OtherStems = make([][StemSize]byte, len(aux.OtherStems))
 	for i, c := range aux.OtherStems {
 		val, err := PrefixedHexStringToBytes(c)
 		if err != nil {

--- a/proof_test.go
+++ b/proof_test.go
@@ -136,7 +136,7 @@ func TestMultiProofVerifyMultipleLeavesWithAbsentStem(t *testing.T) {
 	const leafCount = 10
 
 	var keys [][]byte
-	var absentstem [31]byte
+	var absentstem [StemSize]byte
 	root := New()
 	for i := 0; i < leafCount; i++ {
 		key := make([]byte, 32)
@@ -148,7 +148,7 @@ func TestMultiProofVerifyMultipleLeavesWithAbsentStem(t *testing.T) {
 			keys = append(keys, key)
 		}
 		if i == 3 {
-			copy(absentstem[:], key[:31])
+			copy(absentstem[:], key[:StemSize])
 		}
 	}
 	root.Commit()
@@ -610,7 +610,7 @@ func TestStemStateDiffJSONMarshalUn(t *testing.T) {
 	t.Parallel()
 
 	ssd := StemStateDiff{
-		Stem: [31]byte{10},
+		Stem: [StemSize]byte{10},
 		SuffixDiffs: []SuffixStateDiff{{
 			Suffix: 0x41,
 			CurrentValue: &[32]byte{
@@ -702,7 +702,7 @@ func TestVerkleProofMarshalUnmarshalJSON(t *testing.T) {
 	t.Parallel()
 
 	vp1 := &VerkleProof{
-		OtherStems:            [][31]byte{{1}, {2}, {3}},
+		OtherStems:            [][StemSize]byte{{1}, {2}, {3}},
 		DepthExtensionPresent: []byte{4, 5, 6},
 		CommitmentsByPath:     [][32]byte{{7}, {8}, {9}},
 		D:                     [32]byte{10},
@@ -1125,7 +1125,7 @@ func TestGenerateProofWithOnlyAbsentKeys(t *testing.T) {
 	for i := 0; i < common.VectorLength; i++ {
 		var key [32]byte
 		copy(key[:], presentKey)
-		key[31] = byte(i)
+		key[StemSize] = byte(i)
 		if _, err := droot.Get(key[:], nil); err != errIsPOAStub {
 			t.Fatalf("expected ErrPOALeafValue, got %v", err)
 		}
@@ -1136,7 +1136,7 @@ func TestGenerateProofWithOnlyAbsentKeys(t *testing.T) {
 	for i := 0; i < common.VectorLength; i++ {
 		var key [32]byte
 		copy(key[:], presentKey)
-		key[31] = byte(i)
+		key[StemSize] = byte(i)
 		if err := droot.Insert(key[:], zeroKeyTest, nil); err != errIsPOAStub {
 			t.Fatalf("expected ErrPOALeafValue, got %v", err)
 		}

--- a/tree.go
+++ b/tree.go
@@ -59,7 +59,7 @@ type Stem []byte
 
 func KeyToStem(key []byte) Stem {
 	if len(key) < StemSize {
-		panic(fmt.Errorf("key length (%d) is shorter than expected stem size (%d)", len(key), StemSize))
+		panic(fmt.Errorf("key length (%d) is shorter than the expected stem size (%d)", len(key), StemSize))
 	}
 	return Stem(key[:StemSize])
 }

--- a/tree.go
+++ b/tree.go
@@ -1392,7 +1392,7 @@ func leafToComms(poly []Fr, val []byte) error {
 	if len(val) == 0 {
 		return nil
 	}
-	if len(val) > 32 {
+	if len(val) > LeafValueSize {
 		return fmt.Errorf("invalid leaf length %d, %v", len(val), val)
 	}
 	var (
@@ -1602,7 +1602,7 @@ func (n *LeafNode) Copy() VerkleNode {
 }
 
 func (n *LeafNode) Key(i int) []byte {
-	var ret [32]byte
+	var ret [KeySize]byte
 	copy(ret[:], n.stem)
 	ret[StemSize] = byte(i)
 	return ret[:]

--- a/tree.go
+++ b/tree.go
@@ -1083,7 +1083,7 @@ func (n *LeafNode) Insert(key []byte, value []byte, _ NodeResolverFn) error {
 
 	stem := KeyToStem(key)
 	if !bytes.Equal(stem, n.stem) {
-		return fmt.Errorf("stems doesn't match: %x != %x", stem, n.stem)
+		return fmt.Errorf("stems don't match: %x != %x", stem, n.stem)
 	}
 	values := make([][]byte, NodeWidth)
 	values[key[StemSize]] = value

--- a/tree_ipa_test.go
+++ b/tree_ipa_test.go
@@ -53,7 +53,7 @@ func extensionAndSuffixOneKey(t *testing.T, key, value []byte, ret *Point) {
 		t1, t2, c1                      Point
 	)
 	stemComm0 := srs[0]
-	err := StemFromBytes(&v, key[:31])
+	err := StemFromBytes(&v, KeyToStem(key))
 	if err != nil {
 		panic(err)
 	}
@@ -62,7 +62,7 @@ func extensionAndSuffixOneKey(t *testing.T, key, value []byte, ret *Point) {
 	if err := leafToComms(vs[:], value); err != nil {
 		t.Fatalf("leafToComms failed: %s", err)
 	}
-	c1.Add(t1.ScalarMul(&srs[2*key[31]], &vs[0]), t2.ScalarMul(&srs[2*key[31]+1], &vs[1]))
+	c1.Add(t1.ScalarMul(&srs[2*key[StemSize]], &vs[0]), t2.ScalarMul(&srs[2*key[StemSize]+1], &vs[1]))
 	c1.MapToScalarField(&v)
 	stemComm2.ScalarMul(&srs[2], &v)
 
@@ -165,7 +165,7 @@ func TestInsertSameStemTwoLeaves(t *testing.T) {
 	comm := root.Commit()
 
 	stemComm0 := srs[0]
-	err := StemFromBytes(&v, key_a[:31])
+	err := StemFromBytes(&v, KeyToStem(key_a))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -309,7 +309,7 @@ func TestPaddingInFromLEBytes(t *testing.T) {
 		t.Fatal(err)
 	}
 	key, _ := hex.DecodeString("ffffffffffffffffffffffffffffffff00000000000000000000000000000000")
-	err := StemFromBytes(&fr2, key[:StemSize])
+	err := StemFromBytes(&fr2, KeyToStem(key))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tree_test.go
+++ b/tree_test.go
@@ -165,7 +165,7 @@ func TestOffset2key8BitsWide(t *testing.T) {
 	t.Parallel()
 
 	key, _ := hex.DecodeString("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
-	for i := byte(0); i < 32; i++ {
+	for i := byte(0); i < KeySize; i++ {
 		childId := offset2key(key, i)
 		if childId != i {
 			t.Fatalf("error getting child number in key %d != %d", childId, i)
@@ -579,11 +579,10 @@ func BenchmarkCommitFullNode(b *testing.B) {
 	nChildren := 256
 	keys := make([][]byte, nChildren)
 	for i := 0; i < nChildren; i++ {
-		key := make([]byte, 32)
+		key := make([]byte, KeySize)
 		key[0] = uint8(i)
 		keys[i] = key
 	}
-
 	b.ResetTimer()
 	b.ReportAllocs()
 
@@ -607,8 +606,8 @@ func benchmarkCommitNLeaves(b *testing.B, n int) {
 	sortedKVs := make([]kv, n)
 
 	for i := 0; i < n; i++ {
-		key := make([]byte, 32)
-		val := make([]byte, 32)
+		key := make([]byte, KeySize)
+		val := make([]byte, KeySize)
 		if _, err := rand.Read(key); err != nil {
 			b.Fatalf("failed to generate random key: %v", err)
 		}
@@ -650,7 +649,7 @@ func BenchmarkModifyLeaves(b *testing.B) {
 	keys := make([][]byte, n)
 	root := New()
 	for i := 0; i < n; i++ {
-		key := make([]byte, 32)
+		key := make([]byte, KeySize)
 		if _, err := rand.Read(key); err != nil {
 			b.Fatalf("failed to generate random key: %v", err)
 		}
@@ -681,7 +680,7 @@ func BenchmarkModifyLeaves(b *testing.B) {
 func randomKeys(t *testing.T, n int) [][]byte {
 	keys := make([][]byte, n)
 	for i := 0; i < n; i++ {
-		key := make([]byte, 32)
+		key := make([]byte, KeySize)
 		if _, err := rand.Read(key); err != nil {
 			t.Fatalf("failed to generate random key: %v", err)
 		}
@@ -1111,7 +1110,7 @@ func TestInsertStem(t *testing.T) {
 	}
 	r1c := root1.Commit()
 
-	var key5, key192 [32]byte
+	var key5, key192 [KeySize]byte
 	copy(key5[:], KeyToStem(fourtyKeyTest))
 	copy(key192[:], KeyToStem(fourtyKeyTest))
 	key5[StemSize] = 5
@@ -1502,8 +1501,8 @@ func genRandomKeyValues(rand *mRand.Rand, count int) []keyValue {
 	for i := 0; i < count; i++ {
 		keyval := make([]byte, 64)
 		rand.Read(keyval)
-		ret[i].key = keyval[:32]
-		ret[i].value = keyval[32:]
+		ret[i].key = keyval[:KeySize]
+		ret[i].value = keyval[KeySize:]
 	}
 	return ret
 }
@@ -1702,7 +1701,7 @@ func generateSteps(finished func() bool, r io.Reader) randTest {
 		// we create a new key or return an existing key otherwise.
 		if len(allKeys) < 2 || tmp[0]%100 > 90 {
 			// new key
-			key := make([]byte, 32)
+			key := make([]byte, KeySize)
 			_, err := r.Read(key)
 			if err != nil {
 				panic(err)

--- a/unknown.go
+++ b/unknown.go
@@ -51,7 +51,7 @@ func (UnknownNode) Commitment() *Point {
 	return &id
 }
 
-func (UnknownNode) GetProofItems(keylist, NodeResolverFn) (*ProofElements, []byte, [][]byte, error) {
+func (UnknownNode) GetProofItems(keylist, NodeResolverFn) (*ProofElements, []byte, []Stem, error) {
 	return nil, nil, nil, errors.New("can't generate proof items for unknown node")
 }
 


### PR DESCRIPTION
This PR does the following:
1. Use `Stem []byte` instead of `[]byte`, as well as `KeyToStem(key []byte)` instead of `key[:31]` in most occurrences that require stem. This enhances code readability, without affecting the underlying logic.
2. Replaces `32` with constants `LeafValueSize` or `KeySize` for code maintainability.

**BREAKING CHANGE**:
The `GetProofItems` function in the `VerkleNode` interface now returns `[]Stem` instead of `[][]byte`, which affects geth's usage of this library

Benchmark results:
```
                                        old allocs/op   new allocs/op  delta               
CommitLeaves/insert/leaves/1000-8         16.82k ± ∞ ¹   16.96k ± ∞ ¹  +0.87% (p=0.008 n=5)
CommitLeaves/insert/leaves/10000-8        155.4k ± ∞ ¹   155.3k ± ∞ ¹  -0.11% (p=0.008 n=5)
CommitFullNode-8                          3.795k ± ∞ ¹   3.795k ± ∞ ¹       ~ (p=1.000 n=5) ²
ModifyLeaves-8                            164.4k ± ∞ ¹   164.3k ± ∞ ¹       ~ (p=1.000 n=5)
```