### PR TITLE
chore!: Rename `StemFromBytes` to `StemFromLEBytes`

### DIFF
--- a/conversion.go
+++ b/conversion.go
@@ -62,7 +62,7 @@ func BatchNewLeafNode(nodesValues []BatchNewLeafNodeData) ([]LeafNode, error) {
 				var poly [NodeWidth]Fr
 				poly[0].SetUint64(1)
 				for i, nv := range nodesValues {
-					if err := StemFromBytes(&poly[1], nv.Stem); err != nil {
+					if err := StemFromLEBytes(&poly[1], nv.Stem); err != nil {
 						return err
 					}
 					poly[2] = *c1c2frs[2*i]

--- a/ipa.go
+++ b/ipa.go
@@ -48,7 +48,7 @@ func FromLEBytes(fr *Fr, data []byte) error {
 	return nil
 }
 
-func StemFromBytes(fr *Fr, data []byte) error {
+func StemFromLEBytes(fr *Fr, data []byte) error {
 	if len(data) != StemSize {
 		return errors.New("data length must be StemSize")
 	}

--- a/tree.go
+++ b/tree.go
@@ -300,7 +300,7 @@ func NewLeafNode(stem Stem, values [][]byte) (*LeafNode, error) {
 	stem = stem[:StemSize] // enforce a 31-byte length
 	var poly [NodeWidth]Fr
 	poly[0].SetUint64(1)
-	if err := StemFromBytes(&poly[1], stem); err != nil {
+	if err := StemFromLEBytes(&poly[1], stem); err != nil {
 		return nil, err
 	}
 	if err := banderwagon.BatchMapToScalarField([]*Fr{&poly[2], &poly[3]}, []*Point{c1, c2}); err != nil {
@@ -1434,7 +1434,7 @@ func (n *LeafNode) GetProofItems(keys keylist, _ NodeResolverFn) (*ProofElements
 
 	// Initialize the top-level polynomial with 1 + stem + C1 + C2
 	poly[0].SetUint64(1)
-	if err := StemFromBytes(&poly[1], n.stem); err != nil {
+	if err := StemFromLEBytes(&poly[1], n.stem); err != nil {
 		return nil, nil, nil, fmt.Errorf("error serializing stem '%x': %w", n.stem, err)
 	}
 

--- a/tree_ipa_test.go
+++ b/tree_ipa_test.go
@@ -53,7 +53,7 @@ func extensionAndSuffixOneKey(t *testing.T, key, value []byte, ret *Point) {
 		t1, t2, c1                      Point
 	)
 	stemComm0 := srs[0]
-	err := StemFromBytes(&v, KeyToStem(key))
+	err := StemFromLEBytes(&v, KeyToStem(key))
 	if err != nil {
 		panic(err)
 	}
@@ -165,7 +165,7 @@ func TestInsertSameStemTwoLeaves(t *testing.T) {
 	comm := root.Commit()
 
 	stemComm0 := srs[0]
-	err := StemFromBytes(&v, KeyToStem(key_a))
+	err := StemFromLEBytes(&v, KeyToStem(key_a))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -309,7 +309,7 @@ func TestPaddingInFromLEBytes(t *testing.T) {
 		t.Fatal(err)
 	}
 	key, _ := hex.DecodeString("ffffffffffffffffffffffffffffffff00000000000000000000000000000000")
-	err := StemFromBytes(&fr2, KeyToStem(key))
+	err := StemFromLEBytes(&fr2, KeyToStem(key))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Rationale

This changes the method name to explicitly state that it is using little endian bytes like other methods. Following convention of the library, without LE implies Big endian.