### PR TITLE
mod: update go-ipa

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ethereum/go-verkle
 go 1.19
 
 require (
-	github.com/crate-crypto/go-ipa v0.0.0-20231025140028-3c0104f4b233
+	github.com/crate-crypto/go-ipa v0.0.0-20240223125850-b1e8a79f509c
 	github.com/davecgh/go-spew v1.1.1
 	golang.org/x/sync v0.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/consensys/bavard v0.1.13 h1:oLhMLOFGTLdlda/kma4VOJazblc7IM5y5QPd2A/Yj
 github.com/consensys/bavard v0.1.13/go.mod h1:9ItSMtA/dXMAiL7BG6bqW2m3NdSEObYWoH223nGHukI=
 github.com/consensys/gnark-crypto v0.12.1 h1:lHH39WuuFgVHONRl3J0LRBtuYdQTumFSDtJF7HpyG8M=
 github.com/consensys/gnark-crypto v0.12.1/go.mod h1:v2Gy7L/4ZRosZ7Ivs+9SfUDr0f5UlG+EM5t7MPHiLuY=
-github.com/crate-crypto/go-ipa v0.0.0-20231025140028-3c0104f4b233 h1:d28BXYi+wUpz1KBmiF9bWrjEMacUEREV6MBi2ODnrfQ=
-github.com/crate-crypto/go-ipa v0.0.0-20231025140028-3c0104f4b233/go.mod h1:geZJZH3SzKCqnz5VT0q/DyIG/tvu/dZk+VIfXicupJs=
+github.com/crate-crypto/go-ipa v0.0.0-20240223125850-b1e8a79f509c h1:uQYC5Z1mdLRPrZhHjHxufI8+2UG/i25QG92j0Er9p6I=
+github.com/crate-crypto/go-ipa v0.0.0-20240223125850-b1e8a79f509c/go.mod h1:geZJZH3SzKCqnz5VT0q/DyIG/tvu/dZk+VIfXicupJs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=

--- a/tree.go
+++ b/tree.go
@@ -991,7 +991,7 @@ func (n *InternalNode) Serialize() ([]byte, error) {
 	ret[nodeTypeOffset] = internalRLPType
 
 	// Write the <commitment>
-	comm := n.commitment.BytesUncompressed()
+	comm := n.commitment.BytesUncompressedTrusted()
 	copy(ret[internalCommitmentOffset:], comm[:])
 
 	return ret, nil

--- a/tree_test.go
+++ b/tree_test.go
@@ -705,7 +705,7 @@ func TestNodeSerde(t *testing.T) {
 	if err := tree.Insert(fourtyKeyTest, testValue, nil); err != nil {
 		t.Fatalf("inserting into key2 failed: %v", err)
 	}
-	origComm := tree.Commit().BytesUncompressed()
+	origComm := tree.Commit().BytesUncompressedTrusted()
 	root := tree.(*InternalNode)
 
 	// Serialize all the nodes
@@ -749,10 +749,10 @@ func TestNodeSerde(t *testing.T) {
 	resRoot.children[64] = resLeaf64
 
 	if !isInternalEqual(root, resRoot) {
-		t.Fatalf("parsed node not equal, %x != %x", root.commitment.BytesUncompressed(), resRoot.commitment.BytesUncompressed())
+		t.Fatalf("parsed node not equal, %x != %x", root.commitment.BytesUncompressedTrusted(), resRoot.commitment.BytesUncompressedTrusted())
 	}
 
-	if resRoot.Commitment().BytesUncompressed() != origComm {
+	if resRoot.Commitment().BytesUncompressedTrusted() != origComm {
 		t.Fatal("invalid deserialized commitment")
 	}
 }


### PR DESCRIPTION
Updating `go-ipa` in preparation for upstreaming more changes to go-ethereum for the next Kaustinen network.