### PR TITLE
special serialization for EoAs

### DIFF
--- a/config_ipa.go
+++ b/config_ipa.go
@@ -26,7 +26,6 @@
 package verkle
 
 import (
-	"encoding/hex"
 	"sync"
 
 	"github.com/crate-crypto/go-ipa/ipa"
@@ -74,9 +73,8 @@ func GetConfig() *Config {
 		cfg = &IPAConfig{conf: conf}
 
 		// Initialize the empty code cached values.
-		emptyHashCode, _ := hex.DecodeString("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
 		values := make([][]byte, NodeWidth)
-		values[CodeHashVectorPosition] = emptyHashCode
+		values[CodeHashVectorPosition] = EmptyCodeHash
 		var c1poly [NodeWidth]Fr
 		if _, err := fillSuffixTreePoly(c1poly[:], values[:NodeWidth/2]); err != nil {
 			panic(err)

--- a/encoding.go
+++ b/encoding.go
@@ -58,6 +58,10 @@ const (
 	leafChildrenOffset     = leafC2CommitmentOffset + banderwagon.UncompressedSize
 	leafBalanceSize        = 32
 	leafNonceSize          = 8
+	leafSlotSize           = 32
+	leafValueIndexSize     = 1
+	singleSlotLeafSize     = nodeTypeSize + StemSize + 2*banderwagon.UncompressedSize + leafValueIndexSize + leafSlotSize
+	eoaLeafSize            = nodeTypeSize + StemSize + 2*banderwagon.UncompressedSize + leafBalanceSize + leafNonceSize
 )
 
 func bit(bitlist []byte, nr int) bool {
@@ -71,8 +75,10 @@ var errSerializedPayloadTooShort = errors.New("verkle payload is too short")
 
 // ParseNode deserializes a node into its proper VerkleNode instance.
 // The serialized bytes have the format:
-// - Internal nodes: <nodeType><bitlist><commitment>
-// - Leaf nodes:     <nodeType><stem><bitlist><comm><c1comm><c2comm><children...>
+// - Internal nodes:   <nodeType><bitlist><commitment>
+// - Leaf nodes:       <nodeType><stem><bitlist><comm><c1comm><c2comm><children...>
+// - EoA nodes:        <nodeType><stem><comm><c1comm><balance><nonce>
+// - single slot node: <nodeType><stem><comm><cncomm><leaf index><slot>
 func ParseNode(serializedNode []byte, depth byte) (VerkleNode, error) {
 	// Check that the length of the serialized node is at least the smallest possible serialized node.
 	if len(serializedNode) < nodeTypeSize+banderwagon.UncompressedSize {
@@ -86,6 +92,8 @@ func ParseNode(serializedNode []byte, depth byte) (VerkleNode, error) {
 		return CreateInternalNode(serializedNode[internalBitlistOffset:internalCommitmentOffset], serializedNode[internalCommitmentOffset:], depth)
 	case eoAccountType:
 		return parseEoAccountNode(serializedNode, depth)
+	case singleSlotType:
+		return parseSingleSlotNode(serializedNode, depth)
 	default:
 		return nil, ErrInvalidNodeEncoding
 	}
@@ -141,17 +149,46 @@ func parseEoAccountNode(serialized []byte, depth byte) (VerkleNode, error) {
 	ln := NewLeafNodeWithNoComms(serialized[leafStemOffset:leafStemOffset+StemSize], values[:])
 	ln.setDepth(depth)
 	ln.c1 = new(Point)
-	err := ln.c1.SetBytesUncompressed(serialized[leafStemOffset+StemSize:leafStemOffset+StemSize+banderwagon.UncompressedSize], true)
-	if err != nil {
-		panic(err)
-		// return nil, err
+	if err := ln.c1.SetBytesUncompressed(serialized[leafStemOffset+StemSize:leafStemOffset+StemSize+banderwagon.UncompressedSize], true); err != nil {
+		return nil, fmt.Errorf("error setting leaf C1 commitment: %w", err)
 	}
 	ln.c2 = &banderwagon.Identity
 	ln.commitment = new(Point)
-	err = ln.commitment.SetBytesUncompressed(serialized[leafStemOffset+StemSize+banderwagon.UncompressedSize:leafStemOffset+StemSize+banderwagon.UncompressedSize*2], true)
-	if err != nil {
-		panic(err)
-		// return nil, err
+	if err := ln.commitment.SetBytesUncompressed(serialized[leafStemOffset+StemSize+banderwagon.UncompressedSize:leafStemOffset+StemSize+banderwagon.UncompressedSize*2], true); err != nil {
+		return nil, fmt.Errorf("error setting leaf root commitment: %w", err)
+	}
+	return ln, nil
+}
+
+func parseSingleSlotNode(serialized []byte, depth byte) (VerkleNode, error) {
+	var values [NodeWidth][]byte
+	offset := leafStemOffset
+	ln := NewLeafNodeWithNoComms(serialized[offset:offset+StemSize], values[:])
+	offset += StemSize
+	cnCommBytes := serialized[offset : offset+banderwagon.UncompressedSize]
+	offset += banderwagon.UncompressedSize
+	rootCommBytes := serialized[offset : offset+banderwagon.UncompressedSize]
+	offset += banderwagon.UncompressedSize
+	idx := serialized[offset]
+	offset += leafValueIndexSize
+	values[idx] = serialized[offset : offset+leafSlotSize] // copy slot
+	ln.setDepth(depth)
+	if idx < 128 {
+		ln.c1 = new(Point)
+		if err := ln.c1.SetBytesUncompressed(cnCommBytes, true); err != nil {
+			return nil, fmt.Errorf("error setting leaf C1 commitment: %w", err)
+		}
+		ln.c2 = &banderwagon.Identity
+	} else {
+		ln.c2 = new(Point)
+		if err := ln.c2.SetBytesUncompressed(cnCommBytes, true); err != nil {
+			return nil, fmt.Errorf("error setting leaf C2 commitment: %w", err)
+		}
+		ln.c1 = &banderwagon.Identity
+	}
+	ln.commitment = new(Point)
+	if err := ln.commitment.SetBytesUncompressed(rootCommBytes, true); err != nil {
+		return nil, fmt.Errorf("error setting leaf root commitment: %w", err)
 	}
 	return ln, nil
 }

--- a/encoding.go
+++ b/encoding.go
@@ -142,9 +142,9 @@ func parseEoAccountNode(serialized []byte, depth byte) (VerkleNode, error) {
 	values[1] = serialized[offset : offset+leafBalanceSize] // balance
 	var nonce [32]byte
 	offset += leafBalanceSize
-	copy(nonce[:8], serialized[offset:offset+8])
+	copy(nonce[:leafNonceSize], serialized[offset:offset+leafNonceSize])
 	values[2] = nonce[:] // nonce
-	values[3] = emptyCodeHash[:]
+	values[3] = EmptyCodeHash[:]
 	values[4] = zero32[:] // 0 code size
 	ln := NewLeafNodeWithNoComms(serialized[leafStemOffset:leafStemOffset+StemSize], values[:])
 	ln.setDepth(depth)

--- a/encoding.go
+++ b/encoding.go
@@ -141,10 +141,18 @@ func parseEoAccountNode(serialized []byte, depth byte) (VerkleNode, error) {
 	ln := NewLeafNodeWithNoComms(serialized[leafStemOffset:leafStemOffset+StemSize], values[:])
 	ln.setDepth(depth)
 	ln.c1 = new(Point)
-	ln.c1.SetBytesUncompressed(serialized[leafStemOffset+StemSize:leafStemOffset+StemSize+banderwagon.UncompressedSize], true)
+	err := ln.c1.SetBytesUncompressed(serialized[leafStemOffset+StemSize:leafStemOffset+StemSize+banderwagon.UncompressedSize], true)
+	if err != nil {
+		panic(err)
+		// return nil, err
+	}
 	ln.c2 = &banderwagon.Identity
 	ln.commitment = new(Point)
-	ln.commitment.SetBytesUncompressed(serialized[leafStemOffset+StemSize+banderwagon.UncompressedSize:leafStemOffset+StemSize+banderwagon.UncompressedSize*2], true)
+	err = ln.commitment.SetBytesUncompressed(serialized[leafStemOffset+StemSize+banderwagon.UncompressedSize:leafStemOffset+StemSize+banderwagon.UncompressedSize*2], true)
+	if err != nil {
+		panic(err)
+		// return nil, err
+	}
 	return ln, nil
 }
 

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -54,7 +54,7 @@ func TestInvalidNodeEncoding(t *testing.T) {
 	if err != nil {
 		t.Fatalf("serializing leaf node: %v", err)
 	}
-	lnbytes[0] = leafType + internalType // Change the type of the node to something invalid.
+	lnbytes[0] = 0xc0 // Change the type of the node to something invalid.
 	if _, err := ParseNode(lnbytes, 0); err != ErrInvalidNodeEncoding {
 		t.Fatalf("invalid error, got %v, expected %v", err, ErrInvalidNodeEncoding)
 	}

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -63,9 +63,9 @@ func TestInvalidNodeEncoding(t *testing.T) {
 func TestParseNodeEoA(t *testing.T) {
 	values := make([][]byte, 256)
 	values[0] = zero32[:]
-	values[1] = emptyCodeHash[:] // set empty code hash as balance, because why not
+	values[1] = EmptyCodeHash[:] // set empty code hash as balance, because why not
 	values[2] = fourtyKeyTest[:] // set nonce to 64
-	values[3] = emptyCodeHash[:] // set empty code hash
+	values[3] = EmptyCodeHash[:] // set empty code hash
 	values[4] = zero32[:]        // zero-size
 	ln, err := NewLeafNode(ffx32KeyTest[:31], values)
 	if err != nil {
@@ -103,16 +103,16 @@ func TestParseNodeEoA(t *testing.T) {
 		t.Fatalf("invalid version, got %x, expected %x", lnd.values[0], zero32[:])
 	}
 
-	if !bytes.Equal(lnd.values[1], emptyCodeHash[:]) {
-		t.Fatalf("invalid balance, got %x, expected %x", lnd.values[1], emptyCodeHash[:])
+	if !bytes.Equal(lnd.values[1], EmptyCodeHash[:]) {
+		t.Fatalf("invalid balance, got %x, expected %x", lnd.values[1], EmptyCodeHash[:])
 	}
 
 	if !bytes.Equal(lnd.values[2], fourtyKeyTest[:]) {
 		t.Fatalf("invalid nonce, got %x, expected %x", lnd.values[2], fourtyKeyTest[:])
 	}
 
-	if !bytes.Equal(lnd.values[3], emptyCodeHash[:]) {
-		t.Fatalf("invalid code hash, got %x, expected %x", lnd.values[3], emptyCodeHash[:])
+	if !bytes.Equal(lnd.values[3], EmptyCodeHash[:]) {
+		t.Fatalf("invalid code hash, got %x, expected %x", lnd.values[3], EmptyCodeHash[:])
 	}
 
 	if !bytes.Equal(lnd.values[4], zero32[:]) {
@@ -133,7 +133,7 @@ func TestParseNodeEoA(t *testing.T) {
 }
 func TestParseNodeSingleSlot(t *testing.T) {
 	values := make([][]byte, 256)
-	values[153] = emptyCodeHash
+	values[153] = EmptyCodeHash
 	ln, err := NewLeafNode(ffx32KeyTest[:31], values)
 	if err != nil {
 		t.Fatalf("error creating leaf node: %v", err)
@@ -172,7 +172,7 @@ func TestParseNodeSingleSlot(t *testing.T) {
 				t.Fatalf("value %d, got %x, expected empty slot", i, lnd.values[i])
 			}
 		} else {
-			if !bytes.Equal(lnd.values[i], emptyCodeHash[:]) {
+			if !bytes.Equal(lnd.values[i], EmptyCodeHash[:]) {
 				t.Fatalf("got %x, expected empty slot", lnd.values[i])
 			}
 		}

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -1,6 +1,7 @@
 package verkle
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/crate-crypto/go-ipa/banderwagon"
@@ -38,7 +39,7 @@ func TestInvalidNodeEncoding(t *testing.T) {
 	t.Parallel()
 
 	// Test a short payload.
-	if _, err := ParseNode([]byte{leafRLPType}, 0); err != errSerializedPayloadTooShort {
+	if _, err := ParseNode([]byte{leafType}, 0); err != errSerializedPayloadTooShort {
 		t.Fatalf("invalid error, got %v, expected %v", err, errSerializedPayloadTooShort)
 	}
 
@@ -53,8 +54,81 @@ func TestInvalidNodeEncoding(t *testing.T) {
 	if err != nil {
 		t.Fatalf("serializing leaf node: %v", err)
 	}
-	lnbytes[0] = leafRLPType + internalRLPType // Change the type of the node to something invalid.
+	lnbytes[0] = leafType + internalType // Change the type of the node to something invalid.
 	if _, err := ParseNode(lnbytes, 0); err != ErrInvalidNodeEncoding {
 		t.Fatalf("invalid error, got %v, expected %v", err, ErrInvalidNodeEncoding)
+	}
+}
+
+func TestParseNodeEoA(t *testing.T) {
+	values := make([][]byte, 256)
+	values[0] = zero32[:]
+	values[1] = emptyCodeHash[:] // set empty code hash as balance, because why not
+	values[2] = fourtyKeyTest[:] // set nonce to 64
+	values[3] = emptyCodeHash[:] // set empty code hash
+	values[4] = zero32[:]        // zero-size
+	ln, err := NewLeafNode(ffx32KeyTest[:31], values)
+	if err != nil {
+		t.Fatalf("error creating leaf node: %v", err)
+	}
+
+	serialized, err := ln.Serialize()
+	if err != nil {
+		t.Fatalf("error serializing leaf node: %v", err)
+	}
+
+	if serialized[0] != eoAccountType {
+		t.Fatalf("invalid encoding type, got %d, expected %d", serialized[0], eoAccountType)
+	}
+
+	t.Log(serialized)
+	deserialized, err := ParseNode(serialized, 5)
+	if err != nil {
+		t.Fatalf("error deserializing leaf node: %v", err)
+	}
+
+	lnd, ok := deserialized.(*LeafNode)
+	if !ok {
+		t.Fatalf("expected leaf node, got %T", deserialized)
+	}
+
+	if lnd.depth != 5 {
+		t.Fatalf("invalid depth, got %d, expected %d", lnd.depth, 5)
+	}
+
+	if !bytes.Equal(lnd.stem, ffx32KeyTest[:31]) {
+		t.Fatalf("invalid stem, got %x, expected %x", lnd.stem, ffx32KeyTest[:31])
+	}
+
+	if !bytes.Equal(lnd.values[0], zero32[:]) {
+		t.Fatalf("invalid version, got %x, expected %x", lnd.values[0], zero32[:])
+	}
+
+	if !bytes.Equal(lnd.values[1], emptyCodeHash[:]) {
+		t.Fatalf("invalid balance, got %x, expected %x", lnd.values[1], emptyCodeHash[:])
+	}
+
+	if !bytes.Equal(lnd.values[2], fourtyKeyTest[:]) {
+		t.Fatalf("invalid nonce, got %x, expected %x", lnd.values[2], fourtyKeyTest[:])
+	}
+
+	if !bytes.Equal(lnd.values[3], emptyCodeHash[:]) {
+		t.Fatalf("invalid code hash, got %x, expected %x", lnd.values[3], emptyCodeHash[:])
+	}
+
+	if !bytes.Equal(lnd.values[4], zero32[:]) {
+		t.Fatalf("invalid code size, got %x, expected %x", lnd.values[4], zero32[:])
+	}
+
+	if !lnd.c2.Equal(&banderwagon.Identity) {
+		t.Fatalf("invalid c2, got %x, expected %x", lnd.c2, banderwagon.Identity)
+	}
+
+	if !lnd.c1.Equal(ln.c1) {
+		t.Fatalf("invalid c1, got %x, expected %x", lnd.c1, ln.c1)
+	}
+
+	if !lnd.commitment.Equal(ln.commitment) {
+		t.Fatalf("invalid commitment, got %x, expected %x", lnd.commitment, ln.commitment)
 	}
 }

--- a/tree.go
+++ b/tree.go
@@ -1831,7 +1831,7 @@ func (n *LeafNode) serializeLeafWithUncompressedCommitments(cBytes, c1Bytes, c2B
 		copy(result[leafStemOffset:], n.stem[:StemSize])
 		copy(result[leafStemOffset+StemSize:], c1Bytes[:])
 		copy(result[leafStemOffset+StemSize+banderwagon.UncompressedSize:], cBytes[:])
-		copy(result[leafStemOffset+StemSize+2*banderwagon.UncompressedSize:], n.values[1])                      // copy balance
+		copy(result[leafStemOffset+StemSize+2*banderwagon.UncompressedSize:], n.values[1])                                 // copy balance
 		copy(result[leafStemOffset+StemSize+2*banderwagon.UncompressedSize+leafBalanceSize:], n.values[2][:leafNonceSize]) // copy nonce
 	default:
 		result = make([]byte, nodeTypeSize+StemSize+bitlistSize+3*banderwagon.UncompressedSize+len(children))

--- a/tree.go
+++ b/tree.go
@@ -1763,7 +1763,7 @@ func (n *InternalNode) serializeInternalWithUncompressedCommitment(pointsIdx map
 var (
 	zero24           [24]byte
 	zero32           [32]byte
-	emptyCodeHash, _ = hex.DecodeString("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
+	EmptyCodeHash, _ = hex.DecodeString("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
 )
 
 func (n *LeafNode) serializeLeafWithUncompressedCommitments(cBytes, c1Bytes, c2Bytes [banderwagon.UncompressedSize]byte) []byte {
@@ -1791,20 +1791,22 @@ func (n *LeafNode) serializeLeafWithUncompressedCommitments(cBytes, c1Bytes, c2B
 		if isEoA {
 			switch i {
 			case 0:
+				// Version should be 0
 				isEoA = v != nil && bytes.Equal(v, zero32[:])
 			case 1:
 				// Balance should not be nil
 				isEoA = v != nil
 			case 2:
-				// last 24 bytes should be 0
+				// Nonce should have its last 24 bytes set to 0
 				isEoA = v != nil && bytes.Equal(v[8:32], zero24[:])
 			case 3:
-				isEoA = v != nil && bytes.Equal(v, emptyCodeHash[:])
+				// Code hash should be the empty code hash
+				isEoA = v != nil && bytes.Equal(v, EmptyCodeHash[:])
 			case 4:
-				// code size must be 0
+				// Code size must be 0
 				isEoA = v != nil && bytes.Equal(v, zero32[:])
 			default:
-				// all other values must be nil
+				// All other values must be nil
 				isEoA = v == nil
 			}
 		}

--- a/tree.go
+++ b/tree.go
@@ -1795,9 +1795,7 @@ func (n *LeafNode) serializeLeafWithUncompressedCommitments(cBytes, c1Bytes, c2B
 				// last 24 bytes should be 0
 				isEoA = v != nil && bytes.Equal(v[8:32], zero24[:])
 			case 3:
-				// code hash should be the empty code hash, but let's be tolerant
-				// and accept 0 as well.
-				isEoA = v != nil && (bytes.Equal(v, emptyCodeHash[:]) || bytes.Equal(v, zero32[:]))
+				isEoA = v != nil && bytes.Equal(v, emptyCodeHash[:])
 			case 4:
 				// code size must be 0
 				isEoA = v != nil && bytes.Equal(v, zero32[:])

--- a/tree.go
+++ b/tree.go
@@ -166,9 +166,10 @@ func (pe *ProofElements) Merge(other *ProofElements) {
 const (
 	// These types will distinguish internal
 	// and leaf nodes when decoding from RLP.
-	internalType  byte = 1
-	leafType      byte = 2
-	eoAccountType byte = 3
+	internalType   byte = 1
+	leafType       byte = 2
+	eoAccountType  byte = 3
+	singleSlotType byte = 4
 )
 
 type (
@@ -1772,11 +1773,14 @@ func (n *LeafNode) serializeLeafWithUncompressedCommitments(cBytes, c1Bytes, c2B
 	// Create bitlist and store in children LeafValueSize (padded) values.
 	children := make([]byte, 0, NodeWidth*LeafValueSize)
 	var (
-		bitlist [bitlistSize]byte
-		isEoA   = true
+		bitlist        [bitlistSize]byte
+		isEoA          = true
+		count, lastIdx int
 	)
 	for i, v := range n.values {
 		if v != nil {
+			count++
+			lastIdx = i
 			setBit(bitlist[:], i)
 			children = append(children, v...)
 			if padding := emptyValue[:LeafValueSize-len(v)]; len(padding) != 0 {
@@ -1809,11 +1813,18 @@ func (n *LeafNode) serializeLeafWithUncompressedCommitments(cBytes, c1Bytes, c2B
 	// Create the serialization.
 	var result []byte
 	switch {
-	// TODO case for a group containing a single slot
-	// case count == 1:
+	case count == 1:
+		var buf [singleSlotLeafSize]byte
+		result = buf[:]
+		result[0] = singleSlotType
+		copy(result[leafStemOffset:], n.stem[:StemSize])
+		copy(result[leafStemOffset+StemSize:], c1Bytes[:])
+		copy(result[leafStemOffset+StemSize+banderwagon.UncompressedSize:], cBytes[:])
+		result[leafStemOffset+StemSize+2*banderwagon.UncompressedSize] = byte(lastIdx)
+		copy(result[leafStemOffset+StemSize+2*banderwagon.UncompressedSize+leafValueIndexSize:], n.values[lastIdx][:])
 	case isEoA:
-		baseSize := nodeTypeSize + StemSize + 2*banderwagon.UncompressedSize + leafBalanceSize + leafNonceSize
-		result = make([]byte, baseSize)
+		var buf [eoaLeafSize]byte
+		result = buf[:]
 		result[0] = eoAccountType
 		copy(result[leafStemOffset:], n.stem[:StemSize])
 		copy(result[leafStemOffset+StemSize:], c1Bytes[:])

--- a/tree.go
+++ b/tree.go
@@ -1798,7 +1798,7 @@ func (n *LeafNode) serializeLeafWithUncompressedCommitments(cBytes, c1Bytes, c2B
 				isEoA = v != nil
 			case 2:
 				// Nonce should have its last 24 bytes set to 0
-				isEoA = v != nil && bytes.Equal(v[8:32], zero24[:])
+				isEoA = v != nil && bytes.Equal(v[leafNonceSize:], zero24[:])
 			case 3:
 				// Code hash should be the empty code hash
 				isEoA = v != nil && bytes.Equal(v, EmptyCodeHash[:])
@@ -1832,7 +1832,7 @@ func (n *LeafNode) serializeLeafWithUncompressedCommitments(cBytes, c1Bytes, c2B
 		copy(result[leafStemOffset+StemSize:], c1Bytes[:])
 		copy(result[leafStemOffset+StemSize+banderwagon.UncompressedSize:], cBytes[:])
 		copy(result[leafStemOffset+StemSize+2*banderwagon.UncompressedSize:], n.values[1])                      // copy balance
-		copy(result[leafStemOffset+StemSize+2*banderwagon.UncompressedSize+leafBalanceSize:], n.values[2][0:8]) // copy nonce
+		copy(result[leafStemOffset+StemSize+2*banderwagon.UncompressedSize+leafBalanceSize:], n.values[2][:leafNonceSize]) // copy nonce
 	default:
 		result = make([]byte, nodeTypeSize+StemSize+bitlistSize+3*banderwagon.UncompressedSize+len(children))
 		result[0] = leafType


### PR DESCRIPTION
modifies the (de)serialization code in order to recognize an EoA and pack it more efficiently than a standard group.