### PR TITLE
optimize serialization of single-slot leaves

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -145,17 +145,13 @@ func parseEoAccountNode(serialized []byte, depth byte) (VerkleNode, error) {
 	ln := NewLeafNodeWithNoComms(serialized[leafStemOffset:leafStemOffset+StemSize], values[:])
 	ln.setDepth(depth)
 	ln.c1 = new(Point)
-	err := ln.c1.SetBytesUncompressed(serialized[leafStemOffset+StemSize:leafStemOffset+StemSize+banderwagon.UncompressedSize], true)
-	if err != nil {
-		panic(err)
-		// return nil, err
+	if err := ln.c1.SetBytesUncompressed(serialized[leafStemOffset+StemSize:leafStemOffset+StemSize+banderwagon.UncompressedSize], true); err != nil {
+		return nil, fmt.Errorf("error setting leaf C1 commitment: %w", err)
 	}
 	ln.c2 = &banderwagon.Identity
 	ln.commitment = new(Point)
-	err = ln.commitment.SetBytesUncompressed(serialized[leafStemOffset+StemSize+banderwagon.UncompressedSize:leafStemOffset+StemSize+banderwagon.UncompressedSize*2], true)
-	if err != nil {
-		panic(err)
-		// return nil, err
+	if err := ln.commitment.SetBytesUncompressed(serialized[leafStemOffset+StemSize+banderwagon.UncompressedSize:leafStemOffset+StemSize+banderwagon.UncompressedSize*2], true); err != nil {
+		return nil, fmt.Errorf("error setting leaf root commitment: %w", err)
 	}
 	return ln, nil
 }
@@ -175,16 +171,21 @@ func parseSingleSlotNode(serialized []byte, depth byte) (VerkleNode, error) {
 	ln.setDepth(depth)
 	if idx < 128 {
 		ln.c1 = new(Point)
-		ln.c1.SetBytesUncompressed(cnCommBytes, true)
+		if err := ln.c1.SetBytesUncompressed(cnCommBytes, true); err != nil {
+			return nil, fmt.Errorf("error setting leaf C1 commitment: %w", err)
+		}
 		ln.c2 = &banderwagon.Identity
 	} else {
 		ln.c2 = new(Point)
-		ln.c2.SetBytesUncompressed(cnCommBytes, true)
+		if err := ln.c2.SetBytesUncompressed(cnCommBytes, true); err != nil {
+			return nil, fmt.Errorf("error setting leaf C2 commitment: %w", err)
+		}
 		ln.c1 = &banderwagon.Identity
 	}
-	offset += banderwagon.UncompressedSize
 	ln.commitment = new(Point)
-	ln.commitment.SetBytesUncompressed(rootCommBytes, true)
+	if err := ln.commitment.SetBytesUncompressed(rootCommBytes, true); err != nil {
+		return nil, fmt.Errorf("error setting leaf root commitment: %w", err)
+	}
 	return ln, nil
 }
 

--- a/encoding.go
+++ b/encoding.go
@@ -60,6 +60,8 @@ const (
 	leafNonceSize          = 8
 	leafSlotSize           = 32
 	leafValueIndexSize     = 1
+	singleSlotLeafSize     = nodeTypeSize + StemSize + 2*banderwagon.UncompressedSize + leafValueIndexSize + leafSlotSize
+	eoaLeafSize            = nodeTypeSize + StemSize + 2*banderwagon.UncompressedSize + leafBalanceSize + leafNonceSize
 )
 
 func bit(bitlist []byte, nr int) bool {
@@ -73,8 +75,10 @@ var errSerializedPayloadTooShort = errors.New("verkle payload is too short")
 
 // ParseNode deserializes a node into its proper VerkleNode instance.
 // The serialized bytes have the format:
-// - Internal nodes: <nodeType><bitlist><commitment>
-// - Leaf nodes:     <nodeType><stem><bitlist><comm><c1comm><c2comm><children...>
+// - Internal nodes:   <nodeType><bitlist><commitment>
+// - Leaf nodes:       <nodeType><stem><bitlist><comm><c1comm><c2comm><children...>
+// - EoA nodes:        <nodeType><stem><comm><c1comm><balance><nonce>
+// - single slot node: <nodeType><stem><comm><cncomm><leaf index><slot>
 func ParseNode(serializedNode []byte, depth byte) (VerkleNode, error) {
 	// Check that the length of the serialized node is at least the smallest possible serialized node.
 	if len(serializedNode) < nodeTypeSize+banderwagon.UncompressedSize {

--- a/tree.go
+++ b/tree.go
@@ -1814,8 +1814,8 @@ func (n *LeafNode) serializeLeafWithUncompressedCommitments(cBytes, c1Bytes, c2B
 	var result []byte
 	switch {
 	case count == 1:
-		baseSize := nodeTypeSize + StemSize + 2*banderwagon.UncompressedSize + leafValueIndexSize + leafSlotSize
-		result = make([]byte, baseSize)
+		var buf [singleSlotLeafSize]byte
+		result = buf[:]
 		result[0] = singleSlotType
 		copy(result[leafStemOffset:], n.stem[:StemSize])
 		copy(result[leafStemOffset+StemSize:], c1Bytes[:])
@@ -1823,8 +1823,8 @@ func (n *LeafNode) serializeLeafWithUncompressedCommitments(cBytes, c1Bytes, c2B
 		result[leafStemOffset+StemSize+2*banderwagon.UncompressedSize] = byte(lastIdx)
 		copy(result[leafStemOffset+StemSize+2*banderwagon.UncompressedSize+leafValueIndexSize:], n.values[lastIdx][:])
 	case isEoA:
-		baseSize := nodeTypeSize + StemSize + 2*banderwagon.UncompressedSize + leafBalanceSize + leafNonceSize
-		result = make([]byte, baseSize)
+		var buf [eoaLeafSize]byte
+		result = buf[:]
 		result[0] = eoAccountType
 		copy(result[leafStemOffset:], n.stem[:StemSize])
 		copy(result[leafStemOffset+StemSize:], c1Bytes[:])


### PR DESCRIPTION
Another serialization optimization, for the case of a single leaf.

This could be extended to a group of leaves.