### PR TITLE
fix: include non-root node collectNonHashedNodes

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -1728,8 +1728,9 @@ func (n *InternalNode) collectNonHashedNodes(list []VerkleNode, paths [][]byte, 
 	for i, child := range n.children {
 		switch childNode := child.(type) {
 		case *LeafNode:
+			curDepth := childNode.depth
 			list = append(list, childNode)
-			paths = append(paths, childNode.stem[:len(path)+1])
+			paths = append(paths, append(path, childNode.stem[curDepth-1:curDepth]...))
 		case *InternalNode:
 			childpath := make([]byte, len(path)+1)
 			copy(childpath, path)


### PR DESCRIPTION
In the original implementation of `collectNonHashedNodes`, the function only works when the internal node is root. Since only `BatchSerialize` calls this function by `nodes, paths = n.collectNonHashedNodes(nodes, paths, nil)`, and `BatchSerialize` seems to assume only root will call this function. However, if we want to have any internal node to call `BatchSerialize` without losing generality, we should modify the `collectNonHashedNodes` and make it returns correct leave path correspondingly.