### PR TITLE
fix: left-pad leaves

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -1853,10 +1853,11 @@ func (n *LeafNode) serializeLeafWithUncompressedCommitments(cBytes, c1Bytes, c2B
 			count++
 			lastIdx = i
 			setBit(bitlist[:], i)
-			children = append(children, v...)
+			// left-pad values if this isn't 32-byte aligned
 			if padding := emptyValue[:LeafValueSize-len(v)]; len(padding) != 0 {
 				children = append(children, padding...)
 			}
+			children = append(children, v...)
 		}
 
 		if isEoA {


### PR DESCRIPTION
Values that are less than 32 bytes are right-padded. This was never a problem, because the calling code left-pads them. But there is a pretty weird discrepancy that I would like to fix, and ideally remove the padding in the calling code, so that I can store unpadded-values if need be.