### PR TITLE
Add EIP7736 support 

### DIFF
--- a/benchs/main.go
+++ b/benchs/main.go
@@ -49,7 +49,7 @@ func benchmarkInsertInExisting() {
 		for i := 0; i < 5; i++ {
 			root := verkle.New()
 			for _, k := range keys {
-				if err := root.Insert(k, value, nil); err != nil {
+				if err := root.Insert(k, value, 0, nil); err != nil {
 					panic(err)
 				}
 			}
@@ -58,7 +58,7 @@ func benchmarkInsertInExisting() {
 			// Now insert the 10k leaves and measure time
 			start := time.Now()
 			for _, k := range toInsertKeys {
-				if err := root.Insert(k, value, nil); err != nil {
+				if err := root.Insert(k, value, 0, nil); err != nil {
 					panic(err)
 				}
 			}

--- a/config.go
+++ b/config.go
@@ -35,6 +35,7 @@ const (
 	NodeWidth          = 256
 	NodeBitWidth  byte = 8
 	StemSize           = 31
+	EpochSize          = 8
 )
 
 func equalPaths(key1, key2 []byte) bool {

--- a/debug.go
+++ b/debug.go
@@ -44,4 +44,9 @@ type (
 		C2        [32]byte   `json:"c2"`
 		LastEpoch StateEpoch `json:"last_epoch"`
 	}
+
+	ExportableExpiredLeafNode struct {
+		Stem       Stem     `json:"stem"`
+		Commitment [32]byte `json:"commitment"`
+	}
 )

--- a/debug.go
+++ b/debug.go
@@ -39,8 +39,9 @@ type (
 		Stem   Stem     `json:"stem"`
 		Values [][]byte `json:"values"`
 
-		C  [32]byte `json:"commitment"`
-		C1 [32]byte `json:"c1"`
-		C2 [32]byte `json:"c2"`
+		C         [32]byte   `json:"commitment"`
+		C1        [32]byte   `json:"c1"`
+		C2        [32]byte   `json:"c2"`
+		LastEpoch StateEpoch `json:"last_epoch"`
 	}
 )

--- a/debug_test.go
+++ b/debug_test.go
@@ -33,16 +33,16 @@ func TestJSON(t *testing.T) {
 	t.Parallel()
 
 	root := New()
-	if err := root.Insert(zeroKeyTest, fourtyKeyTest, nil); err != nil {
+	if err := root.Insert(zeroKeyTest, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := root.Insert(oneKeyTest, zeroKeyTest, nil); err != nil {
+	if err := root.Insert(oneKeyTest, zeroKeyTest, 0, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := root.Insert(forkOneKeyTest, zeroKeyTest, nil); err != nil { // Force an internal node in the first layer.
+	if err := root.Insert(forkOneKeyTest, zeroKeyTest, 0, nil); err != nil { // Force an internal node in the first layer.
 		t.Fatal(err)
 	}
-	if err := root.Insert(fourtyKeyTest, oneKeyTest, nil); err != nil {
+	if err := root.Insert(fourtyKeyTest, oneKeyTest, 0, nil); err != nil {
 		t.Fatal(err)
 	}
 	root.(*InternalNode).children[152] = HashedNode{}

--- a/doc.go
+++ b/doc.go
@@ -38,9 +38,7 @@ var (
 	errUnknownNodeType        = errors.New("unknown node type detected")
 	errMissingNodeInStateless = errors.New("trying to access a node that is missing from the stateless view")
 	errIsPOAStub              = errors.New("trying to read/write a proof of absence leaf node")
-	errExpiredLeafNode        = errors.New("trying to access an expired leaf node")
-	errExpiredNodeNotFound    = errors.New("cannot find expired node when reviving")
-	errEpochExpired           = errors.New("trying to access an expired node")
+	errEpochExpired           = errors.New("trying to access an expired leaf node")
 )
 
 const (

--- a/doc.go
+++ b/doc.go
@@ -40,6 +40,7 @@ var (
 	errIsPOAStub              = errors.New("trying to read/write a proof of absence leaf node")
 	errExpiredLeafNode        = errors.New("trying to access an expired leaf node")
 	errExpiredNodeNotFound    = errors.New("cannot find expired node when reviving")
+	errEpochExpired           = errors.New("trying to access an expired node")
 )
 
 const (

--- a/doc.go
+++ b/doc.go
@@ -38,6 +38,8 @@ var (
 	errUnknownNodeType        = errors.New("unknown node type detected")
 	errMissingNodeInStateless = errors.New("trying to access a node that is missing from the stateless view")
 	errIsPOAStub              = errors.New("trying to read/write a proof of absence leaf node")
+	errExpiredLeafNode        = errors.New("trying to access an expired leaf node")
+	errExpiredNodeNotFound    = errors.New("cannot find expired node when reviving")
 )
 
 const (

--- a/empty.go
+++ b/empty.go
@@ -39,7 +39,7 @@ func (Empty) Delete([]byte, StateEpoch, NodeResolverFn) (bool, error) {
 	return false, errors.New("cant delete an empty node")
 }
 
-func (Empty) Get([]byte, NodeResolverFn) ([]byte, error) {
+func (Empty) Get([]byte, StateEpoch, NodeResolverFn) ([]byte, error) {
 	return nil, nil
 }
 

--- a/empty.go
+++ b/empty.go
@@ -31,11 +31,11 @@ type Empty struct{}
 
 var errDirectInsertIntoEmptyNode = errors.New("an empty node should not be inserted directly into")
 
-func (Empty) Insert([]byte, []byte, NodeResolverFn) error {
+func (Empty) Insert([]byte, []byte, StateEpoch, NodeResolverFn) error {
 	return errDirectInsertIntoEmptyNode
 }
 
-func (Empty) Delete([]byte, NodeResolverFn) (bool, error) {
+func (Empty) Delete([]byte, StateEpoch, NodeResolverFn) (bool, error) {
 	return false, errors.New("cant delete an empty node")
 }
 

--- a/empty_test.go
+++ b/empty_test.go
@@ -39,7 +39,7 @@ func TestEmptyFuncs(t *testing.T) {
 	if err == nil {
 		t.Fatal("got nil error when deleting from empty")
 	}
-	v, err := e.Get(zeroKeyTest, nil)
+	v, err := e.Get(zeroKeyTest, 0, nil)
 	if err != nil {
 		t.Fatal("got non-nil error when getting from empty")
 	}

--- a/empty_test.go
+++ b/empty_test.go
@@ -31,11 +31,11 @@ func TestEmptyFuncs(t *testing.T) {
 	t.Parallel()
 
 	var e Empty
-	err := e.Insert(zeroKeyTest, zeroKeyTest, nil)
+	err := e.Insert(zeroKeyTest, zeroKeyTest, 0, nil)
 	if err == nil {
 		t.Fatal("got nil error when inserting into empty")
 	}
-	_, err = e.Delete(zeroKeyTest, nil)
+	_, err = e.Delete(zeroKeyTest, 0, nil)
 	if err == nil {
 		t.Fatal("got nil error when deleting from empty")
 	}

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -22,7 +22,7 @@ func TestLeafStemLength(t *testing.T) {
 	// Serialize a leaf with no values, but whose stem is 32 bytes. The
 	// serialization should trim the extra byte.
 	toolong := make([]byte, 32)
-	leaf, err := NewLeafNode(toolong, make([][]byte, NodeWidth))
+	leaf, err := NewLeafNode(toolong, make([][]byte, NodeWidth), 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -30,7 +30,7 @@ func TestLeafStemLength(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(ser) != nodeTypeSize+StemSize+bitlistSize+3*banderwagon.UncompressedSize {
+	if len(ser) != nodeTypeSize+StemSize+bitlistSize+3*banderwagon.UncompressedSize+EpochSize {
 		t.Fatalf("invalid serialization when the stem is longer than 31 bytes: %x (%d bytes != %d)", ser, len(ser), nodeTypeSize+StemSize+bitlistSize+2*banderwagon.UncompressedSize)
 	}
 }
@@ -46,7 +46,7 @@ func TestInvalidNodeEncoding(t *testing.T) {
 	// Test an invalid node type.
 	values := make([][]byte, NodeWidth)
 	values[42] = testValue
-	ln, err := NewLeafNode(ffx32KeyTest, values)
+	ln, err := NewLeafNode(ffx32KeyTest, values, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -67,7 +67,7 @@ func TestParseNodeEoA(t *testing.T) {
 	values[2] = fourtyKeyTest[:] // set nonce to 64
 	values[3] = EmptyCodeHash[:] // set empty code hash
 	values[4] = zero32[:]        // zero-size
-	ln, err := NewLeafNode(ffx32KeyTest[:31], values)
+	ln, err := NewLeafNode(ffx32KeyTest[:31], values, 0)
 	if err != nil {
 		t.Fatalf("error creating leaf node: %v", err)
 	}
@@ -131,10 +131,11 @@ func TestParseNodeEoA(t *testing.T) {
 		t.Fatalf("invalid commitment, got %x, expected %x", lnd.commitment, ln.commitment)
 	}
 }
+
 func TestParseNodeSingleSlot(t *testing.T) {
 	values := make([][]byte, 256)
 	values[153] = EmptyCodeHash
-	ln, err := NewLeafNode(ffx32KeyTest[:31], values)
+	ln, err := NewLeafNode(ffx32KeyTest[:31], values, 0)
 	if err != nil {
 		t.Fatalf("error creating leaf node: %v", err)
 	}

--- a/expired_leaf.go
+++ b/expired_leaf.go
@@ -1,0 +1,102 @@
+// This is free and unencumbered software released into the public domain.
+//
+// Anyone is free to copy, modify, publish, use, compile, sell, or
+// distribute this software, either in source code form or as a compiled
+// binary, for any purpose, commercial or non-commercial, and by any
+// means.
+//
+// In jurisdictions that recognize copyright laws, the author or authors
+// of this software dedicate any and all copyright interest in the
+// software to the public domain. We make this dedication for the benefit
+// of the public at large and to the detriment of our heirs and
+// successors. We intend this dedication to be an overt act of
+// relinquishment in perpetuity of all present and future rights to this
+// software under copyright law.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+//
+// For more information, please refer to <https://unlicense.org>
+
+package verkle
+
+import (
+	"errors"
+)
+
+type ExpiredLeafNode struct {
+	stem       Stem
+	commitment *Point
+}
+
+var errExpiredLeafNode = errors.New("trying to access an expired leaf node")
+
+func (ExpiredLeafNode) Insert([]byte, []byte, StateEpoch, NodeResolverFn) error {
+	return errExpiredLeafNode
+}
+
+func (ExpiredLeafNode) Delete([]byte, StateEpoch, NodeResolverFn) (bool, error) {
+	return false, errExpiredLeafNode
+}
+
+func (ExpiredLeafNode) Get([]byte, NodeResolverFn) ([]byte, error) {
+	return nil, errExpiredLeafNode
+}
+
+func (n ExpiredLeafNode) Commit() *Point {
+	if n.commitment == nil {
+		panic("nil commitment")
+	}
+	return n.commitment
+}
+
+func (n ExpiredLeafNode) Commitment() *Point {
+	return n.commitment
+}
+
+func (n ExpiredLeafNode) GetProofItems(keylist, NodeResolverFn) (*ProofElements, []byte, []Stem, error) {
+	return nil, nil, nil, errExpiredLeafNode
+}
+
+func (n ExpiredLeafNode) Serialize() ([]byte, error) {
+	cBytes := n.commitment.Bytes()
+
+	var buf [expiredLeafSize]byte
+	result := buf[:]
+	result[0] = expiredLeafType
+	copy(result[leafStemOffset:], n.stem[:StemSize])
+	copy(result[leafStemOffset+StemSize:], cBytes[:])
+
+	return result, nil
+}
+
+func (n ExpiredLeafNode) Copy() VerkleNode {
+	l := &ExpiredLeafNode{}
+	l.stem = make(Stem, len(n.stem))
+
+	if n.commitment != nil {
+		l.commitment = new(Point)
+		l.commitment.Set(n.commitment)
+	}
+
+	return l
+}
+
+func (n ExpiredLeafNode) toDot(string, string) string {
+	return ""
+}
+
+func (n ExpiredLeafNode) setDepth(_ byte) {
+	panic("should not be try to set the depth of an ExpiredLeafNode node")
+}
+
+func (n ExpiredLeafNode) Hash() *Fr {
+	var hash Fr
+	n.commitment.MapToScalarField(&hash)
+	return &hash
+}

--- a/expired_leaf.go
+++ b/expired_leaf.go
@@ -44,7 +44,7 @@ func (ExpiredLeafNode) Delete([]byte, StateEpoch, NodeResolverFn) (bool, error) 
 	return false, errExpiredLeafNode
 }
 
-func (ExpiredLeafNode) Get([]byte, NodeResolverFn) ([]byte, error) {
+func (ExpiredLeafNode) Get([]byte, StateEpoch, NodeResolverFn) ([]byte, error) {
 	return nil, errExpiredLeafNode
 }
 

--- a/hashednode.go
+++ b/hashednode.go
@@ -32,11 +32,11 @@ import (
 
 type HashedNode struct{}
 
-func (HashedNode) Insert([]byte, []byte, NodeResolverFn) error {
+func (HashedNode) Insert([]byte, []byte, StateEpoch, NodeResolverFn) error {
 	return errInsertIntoHash
 }
 
-func (HashedNode) Delete([]byte, NodeResolverFn) (bool, error) {
+func (HashedNode) Delete([]byte, StateEpoch, NodeResolverFn) (bool, error) {
 	return false, errors.New("cant delete a hashed node in-place")
 }
 

--- a/hashednode.go
+++ b/hashednode.go
@@ -40,7 +40,7 @@ func (HashedNode) Delete([]byte, StateEpoch, NodeResolverFn) (bool, error) {
 	return false, errors.New("cant delete a hashed node in-place")
 }
 
-func (HashedNode) Get([]byte, NodeResolverFn) ([]byte, error) {
+func (HashedNode) Get([]byte, StateEpoch, NodeResolverFn) ([]byte, error) {
 	return nil, errors.New("can not read from a hash node")
 }
 

--- a/hashednode_test.go
+++ b/hashednode_test.go
@@ -39,7 +39,7 @@ func TestHashedNodeFuncs(t *testing.T) {
 	if err == nil {
 		t.Fatal("got nil error when deleting from a hashed node")
 	}
-	v, err := e.Get(zeroKeyTest, nil)
+	v, err := e.Get(zeroKeyTest, 0, nil)
 	if err == nil {
 		t.Fatal("got nil error when getting from a hashed node")
 	}

--- a/hashednode_test.go
+++ b/hashednode_test.go
@@ -31,11 +31,11 @@ func TestHashedNodeFuncs(t *testing.T) {
 	t.Parallel()
 
 	e := HashedNode{}
-	err := e.Insert(zeroKeyTest, zeroKeyTest, nil)
+	err := e.Insert(zeroKeyTest, zeroKeyTest, 0, nil)
 	if err != errInsertIntoHash {
 		t.Fatal("got nil error when inserting into a hashed node")
 	}
-	_, err = e.Delete(zeroKeyTest, nil)
+	_, err = e.Delete(zeroKeyTest, 0, nil)
 	if err == nil {
 		t.Fatal("got nil error when deleting from a hashed node")
 	}

--- a/proof_ipa.go
+++ b/proof_ipa.go
@@ -260,7 +260,7 @@ func SerializeProof(proof *Proof) (*VerkleProof, StateDiff, error) {
 		stemdiff.SuffixDiffs = append(stemdiff.SuffixDiffs, SuffixStateDiff{Suffix: key[StemSize]})
 		newsd := &stemdiff.SuffixDiffs[len(stemdiff.SuffixDiffs)-1]
 
-		var valueLen = len(proof.PreValues[i])
+		valueLen := len(proof.PreValues[i])
 		switch valueLen {
 		case 0:
 			// null value
@@ -540,7 +540,8 @@ func PostStateTreeFromStateDiff(preroot VerkleNode, statediff StateDiff) (Verkle
 		if overwrites {
 			var stem [StemSize]byte
 			copy(stem[:StemSize], stemstatediff.Stem[:])
-			if err := postroot.(*InternalNode).InsertValuesAtStem(stem[:], values, nil); err != nil {
+			// TODO(weiihann): double check the epoch
+			if err := postroot.(*InternalNode).InsertValuesAtStem(stem[:], values, 0, nil); err != nil {
 				return nil, fmt.Errorf("error overwriting value in post state: %w", err)
 			}
 		}
@@ -558,7 +559,6 @@ func (x bytesSlice) Swap(i, j int)      { x[i], x[j] = x[j], x[i] }
 
 // Verify is the API function that verifies a verkle proofs as found in a block/execution payload.
 func Verify(vp *VerkleProof, preStateRoot []byte, postStateRoot []byte, statediff StateDiff) error {
-
 	proof, err := DeserializeProof(vp, statediff)
 	if err != nil {
 		return fmt.Errorf("verkle proof deserialization error: %w", err)

--- a/proof_ipa.go
+++ b/proof_ipa.go
@@ -145,7 +145,7 @@ func getProofElementsFromTree(preroot, postroot VerkleNode, keys [][]byte, resol
 		// keys were sorted already in the above GetcommitmentsForMultiproof.
 		// Set the post values, if they are untouched, leave them `nil`
 		for i := range keys {
-			val, err := postroot.Get(keys[i], resolver)
+			val, err := postroot.Get(keys[i], 0, resolver)
 			if err != nil {
 				return nil, nil, nil, nil, fmt.Errorf("error getting post-state value for key %x: %w", keys[i], err)
 			}
@@ -580,7 +580,7 @@ func Verify(vp *VerkleProof, preStateRoot []byte, postStateRoot []byte, statedif
 			copy(key[:31], stemdiff.Stem[:])
 			key[31] = suffixdiff.Suffix
 
-			val, err := pretree.Get(key[:], nil)
+			val, err := pretree.Get(key[:], 0, nil)
 			if err != nil {
 				return fmt.Errorf("could not find key %x in tree rebuilt from proof: %w", key, err)
 			}

--- a/proof_test.go
+++ b/proof_test.go
@@ -53,13 +53,13 @@ func TestProofVerifyTwoLeaves(t *testing.T) {
 	t.Parallel()
 
 	root := New()
-	if err := root.Insert(zeroKeyTest, zeroKeyTest, nil); err != nil {
+	if err := root.Insert(zeroKeyTest, zeroKeyTest, 0, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := root.Insert(oneKeyTest, zeroKeyTest, nil); err != nil {
+	if err := root.Insert(oneKeyTest, zeroKeyTest, 0, nil); err != nil {
 		t.Fatalf("could not insert key: %v", err)
 	}
-	if err := root.Insert(ffx32KeyTest, zeroKeyTest, nil); err != nil {
+	if err := root.Insert(ffx32KeyTest, zeroKeyTest, 0, nil); err != nil {
 		t.Fatalf("could not insert key: %v", err)
 	}
 	root.Commit()
@@ -85,7 +85,7 @@ func TestProofVerifyMultipleLeaves(t *testing.T) {
 			t.Fatalf("could not read random bytes: %v", err)
 		}
 		keys[i] = key
-		if err := root.Insert(key, fourtyKeyTest, nil); err != nil {
+		if err := root.Insert(key, fourtyKeyTest, 0, nil); err != nil {
 			t.Fatalf("could not insert key: %v", err)
 		}
 	}
@@ -112,7 +112,7 @@ func TestMultiProofVerifyMultipleLeaves(t *testing.T) {
 			t.Fatalf("could not read random bytes: %v", err)
 		}
 		keys[i] = key
-		if err := root.Insert(key, fourtyKeyTest, nil); err != nil {
+		if err := root.Insert(key, fourtyKeyTest, 0, nil); err != nil {
 			t.Fatalf("could not insert key: %v", err)
 		}
 	}
@@ -141,7 +141,7 @@ func TestMultiProofVerifyMultipleLeavesWithAbsentStem(t *testing.T) {
 	for i := 0; i < leafCount; i++ {
 		key := make([]byte, 32)
 		key[2] = byte(i)
-		if err := root.Insert(key, fourtyKeyTest, nil); err != nil {
+		if err := root.Insert(key, fourtyKeyTest, 0, nil); err != nil {
 			t.Fatalf("could not insert key: %v", err)
 		}
 		if i%2 == 0 {
@@ -183,11 +183,11 @@ func TestMultiProofVerifyMultipleLeavesCommitmentRedundancy(t *testing.T) {
 	keys := make([][]byte, 2)
 	root := New()
 	keys[0] = zeroKeyTest
-	if err := root.Insert(keys[0], fourtyKeyTest, nil); err != nil {
+	if err := root.Insert(keys[0], fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("could not insert key: %v", err)
 	}
 	keys[1] = oneKeyTest
-	if err := root.Insert(keys[1], fourtyKeyTest, nil); err != nil {
+	if err := root.Insert(keys[1], fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("could not insert key: %v", err)
 	}
 	root.Commit()
@@ -208,10 +208,10 @@ func TestProofOfAbsenceInternalVerify(t *testing.T) {
 	t.Parallel()
 
 	root := New()
-	if err := root.Insert(zeroKeyTest, zeroKeyTest, nil); err != nil {
+	if err := root.Insert(zeroKeyTest, zeroKeyTest, 0, nil); err != nil {
 		t.Fatalf("could not insert key: %v", err)
 	}
-	if err := root.Insert(oneKeyTest, zeroKeyTest, nil); err != nil {
+	if err := root.Insert(oneKeyTest, zeroKeyTest, 0, nil); err != nil {
 		t.Fatalf("could not insert key: %v", err)
 	}
 	root.Commit()
@@ -228,10 +228,10 @@ func TestProofOfAbsenceLeafVerify(t *testing.T) {
 	t.Parallel()
 
 	root := New()
-	if err := root.Insert(zeroKeyTest, zeroKeyTest, nil); err != nil {
+	if err := root.Insert(zeroKeyTest, zeroKeyTest, 0, nil); err != nil {
 		t.Fatalf("could not insert key: %v", err)
 	}
-	if err := root.Insert(ffx32KeyTest, zeroKeyTest, nil); err != nil {
+	if err := root.Insert(ffx32KeyTest, zeroKeyTest, 0, nil); err != nil {
 		t.Fatalf("could not insert key: %v", err)
 	}
 	root.Commit()
@@ -243,14 +243,15 @@ func TestProofOfAbsenceLeafVerify(t *testing.T) {
 		t.Fatal("could not verify verkle proof")
 	}
 }
+
 func TestProofOfAbsenceLeafVerifyOtherSuffix(t *testing.T) {
 	t.Parallel()
 
 	root := New()
-	if err := root.Insert(zeroKeyTest, zeroKeyTest, nil); err != nil {
+	if err := root.Insert(zeroKeyTest, zeroKeyTest, 0, nil); err != nil {
 		t.Fatalf("could not insert key: %v", err)
 	}
-	if err := root.Insert(ffx32KeyTest, zeroKeyTest, nil); err != nil {
+	if err := root.Insert(ffx32KeyTest, zeroKeyTest, 0, nil); err != nil {
 		t.Fatalf("could not insert key: %v", err)
 	}
 	root.Commit()
@@ -272,7 +273,7 @@ func TestProofOfAbsenceStemVerify(t *testing.T) {
 	t.Parallel()
 
 	root := New()
-	if err := root.Insert(zeroKeyTest, zeroKeyTest, nil); err != nil {
+	if err := root.Insert(zeroKeyTest, zeroKeyTest, 0, nil); err != nil {
 		t.Fatalf("could not insert key: %v", err)
 	}
 
@@ -299,7 +300,7 @@ func BenchmarkProofCalculation(b *testing.B) {
 			b.Fatal(err)
 		}
 		keys[i] = key
-		if err := root.Insert(key, zeroKeyTest, nil); err != nil {
+		if err := root.Insert(key, zeroKeyTest, 0, nil); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -323,7 +324,7 @@ func BenchmarkProofVerification(b *testing.B) {
 			b.Fatal(err)
 		}
 		keys[i] = key
-		if err := root.Insert(key, zeroKeyTest, nil); err != nil {
+		if err := root.Insert(key, zeroKeyTest, 0, nil); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -355,7 +356,7 @@ func TestProofSerializationNoAbsentStem(t *testing.T) {
 			t.Fatalf("could not read random bytes: %v", err)
 		}
 		keys[i] = key
-		if err := root.Insert(key, fourtyKeyTest, nil); err != nil {
+		if err := root.Insert(key, fourtyKeyTest, 0, nil); err != nil {
 			t.Fatalf("could not insert key: %v", err)
 		}
 	}
@@ -386,7 +387,7 @@ func TestProofSerializationWithAbsentStem(t *testing.T) {
 		key := make([]byte, 32)
 		key[2] = byte(i)
 		keys[i] = key
-		if err := root.Insert(key, fourtyKeyTest, nil); err != nil {
+		if err := root.Insert(key, fourtyKeyTest, 0, nil); err != nil {
 			t.Fatalf("could not insert key: %v", err)
 		}
 	}
@@ -427,7 +428,7 @@ func TestProofDeserialize(t *testing.T) {
 		key := make([]byte, 32)
 		key[2] = byte(i)
 		keys[i] = key
-		if err := root.Insert(key, fourtyKeyTest, nil); err != nil {
+		if err := root.Insert(key, fourtyKeyTest, 0, nil); err != nil {
 			t.Fatalf("could not insert key: %v", err)
 		}
 	}
@@ -484,7 +485,7 @@ func TestProofOfAbsenceOtherMultipleLeaves(t *testing.T) {
 	// but does look the same for most of its length.
 	root := New()
 	key, _ := hex.DecodeString("0303030303030303030303030303030303030303030303030303030303030000")
-	if err := root.Insert(key, testValue, nil); err != nil {
+	if err := root.Insert(key, testValue, 0, nil); err != nil {
 		t.Fatalf("could not insert key: %v", err)
 	}
 	rootC := root.Commit()
@@ -518,7 +519,7 @@ func TestProofOfAbsenceOtherMultipleLeaves(t *testing.T) {
 	// proven for absence, but needs to be inserted in the proof-of-absence stem.
 	// It differs from the poa stem here: 🠃
 	ret3, _ := hex.DecodeString("0303030304030303030303030303030303030303030303030303030303030300")
-	err = deserialized.Insert(ret3, testValue, nil)
+	err = deserialized.Insert(ret3, testValue, 0, nil)
 	if err != nil {
 		t.Fatalf("error inserting value in proof-of-asbsence stem: %v", err)
 	}
@@ -546,7 +547,7 @@ func TestProofOfAbsenceNoneMultipleStems(t *testing.T) {
 
 	root := New()
 	key, _ := hex.DecodeString("0403030303030303030303030303030303030303030303030303030303030000")
-	if err := root.Insert(key, testValue, nil); err != nil {
+	if err := root.Insert(key, testValue, 0, nil); err != nil {
 		t.Fatalf("could not insert key: %v", err)
 	}
 	root.Commit()
@@ -842,7 +843,7 @@ func testSerializeDeserializeProof(t *testing.T, insertKVs map[string][]byte, pr
 	root := New()
 
 	for k, v := range insertKVs {
-		if err := root.Insert([]byte(k), v, nil); err != nil {
+		if err := root.Insert([]byte(k), v, 0, nil); err != nil {
 			t.Fatalf("could not insert key: %v", err)
 		}
 	}
@@ -997,7 +998,7 @@ func TestProofVerificationWithPostState(t *testing.T) { // skipcq: GO-R1005
 
 			root := New()
 			for i := range data.keys {
-				if err := root.Insert(data.keys[i], data.values[i], nil); err != nil {
+				if err := root.Insert(data.keys[i], data.values[i], 0, nil); err != nil {
 					t.Fatalf("could not insert key: %v", err)
 				}
 			}
@@ -1005,7 +1006,7 @@ func TestProofVerificationWithPostState(t *testing.T) { // skipcq: GO-R1005
 
 			postroot := root.Copy()
 			for i := range data.updatekeys {
-				if err := postroot.Insert(data.updatekeys[i], data.updatevalues[i], nil); err != nil {
+				if err := postroot.Insert(data.updatekeys[i], data.updatevalues[i], 0, nil); err != nil {
 					t.Fatalf("could not insert key: %v", err)
 				}
 			}
@@ -1081,7 +1082,7 @@ func TestGenerateProofWithOnlyAbsentKeys(t *testing.T) {
 	// Create a tree with only one key.
 	root := New()
 	presentKey, _ := hex.DecodeString("4000000000000000000000000000000000000000000000000000000000000000")
-	if err := root.Insert(presentKey, zeroKeyTest, nil); err != nil {
+	if err := root.Insert(presentKey, zeroKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into the original failed: %v", err)
 	}
 	root.Commit()
@@ -1142,7 +1143,7 @@ func TestGenerateProofWithOnlyAbsentKeys(t *testing.T) {
 		var key [32]byte
 		copy(key[:], presentKey)
 		key[StemSize] = byte(i)
-		if err := droot.Insert(key[:], zeroKeyTest, nil); err != errIsPOAStub {
+		if err := droot.Insert(key[:], zeroKeyTest, 0, nil); err != errIsPOAStub {
 			t.Fatalf("expected ErrPOALeafValue, got %v", err)
 		}
 	}
@@ -1157,10 +1158,10 @@ func TestDoubleProofOfAbsence(t *testing.T) {
 	key11, _ := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000001")
 	key12, _ := hex.DecodeString("0003000000000000000000000000000000000000000000000000000000000001")
 
-	if err := root.Insert(key11, fourtyKeyTest, nil); err != nil {
+	if err := root.Insert(key11, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("could not insert key: %v", err)
 	}
-	if err := root.Insert(key12, fourtyKeyTest, nil); err != nil {
+	if err := root.Insert(key12, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("could not insert key: %v", err)
 	}
 
@@ -1208,10 +1209,10 @@ func TestProveAbsenceInEmptyHalf(t *testing.T) {
 
 	key1, _ := hex.DecodeString("00000000000000000000000000000000000000000000000000000000000000FF")
 
-	if err := root.Insert(key1, fourtyKeyTest, nil); err != nil {
+	if err := root.Insert(key1, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("could not insert key: %v", err)
 	}
-	if err := root.Insert(key1, fourtyKeyTest, nil); err != nil {
+	if err := root.Insert(key1, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("could not insert key: %v", err)
 	}
 

--- a/proof_test.go
+++ b/proof_test.go
@@ -507,7 +507,7 @@ func TestProofOfAbsenceOtherMultipleLeaves(t *testing.T) {
 		t.Fatalf("error deserializing %v", err)
 	}
 
-	got, err := deserialized.Get(ret1, nil)
+	got, err := deserialized.Get(ret1, 0, nil)
 	if err != nil {
 		t.Fatalf("error while trying to read missing value: %v", err)
 	}
@@ -1132,7 +1132,7 @@ func TestGenerateProofWithOnlyAbsentKeys(t *testing.T) {
 		var key [32]byte
 		copy(key[:], presentKey)
 		key[StemSize] = byte(i)
-		if _, err := droot.Get(key[:], nil); err != errIsPOAStub {
+		if _, err := droot.Get(key[:], 0, nil); err != errIsPOAStub {
 			t.Fatalf("expected ErrPOALeafValue, got %v", err)
 		}
 	}

--- a/state_epoch.go
+++ b/state_epoch.go
@@ -1,0 +1,27 @@
+package verkle
+
+import (
+	"encoding/binary"
+)
+
+type StateEpoch uint64
+
+const (
+	NumActiveEpochs = 2
+)
+
+func EpochExpired(prev StateEpoch, cur StateEpoch) bool {
+	return cur-prev >= NumActiveEpochs
+}
+
+// Convert epoch to bytes
+func (e StateEpoch) Bytes() []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, uint64(e))
+	return b
+}
+
+// Get the state epoch from bytes
+func StateEpochFromBytes(b []byte) StateEpoch {
+	return StateEpoch(binary.BigEndian.Uint64(b))
+}

--- a/tree.go
+++ b/tree.go
@@ -1161,6 +1161,10 @@ func (n *LeafNode) Insert(key []byte, value []byte, curEpoch StateEpoch, _ NodeR
 		return fmt.Errorf("invalid key size: %d", len(key))
 	}
 
+	if EpochExpired(n.lastEpoch, curEpoch) {
+		return errEpochExpired
+	}
+
 	stem := KeyToStem(key)
 	if !bytes.Equal(stem, n.stem) {
 		return fmt.Errorf("stems don't match: %x != %x", stem, n.stem)
@@ -1337,6 +1341,10 @@ func (n *LeafNode) Delete(k []byte, curEpoch StateEpoch, _ NodeResolverFn) (bool
 	// Sanity check: ensure the key header is the same:
 	if !equalPaths(k, n.stem) {
 		return false, nil
+	}
+
+	if EpochExpired(n.lastEpoch, curEpoch) {
+		return false, errEpochExpired
 	}
 
 	// Erase the value it used to contain

--- a/tree.go
+++ b/tree.go
@@ -67,10 +67,10 @@ func KeyToStem(key []byte) Stem {
 
 type VerkleNode interface {
 	// Insert or Update value into the tree
-	Insert([]byte, []byte, NodeResolverFn) error
+	Insert([]byte, []byte, StateEpoch, NodeResolverFn) error
 
 	// Delete a leaf with the given key
-	Delete([]byte, NodeResolverFn) (bool, error)
+	Delete([]byte, StateEpoch, NodeResolverFn) (bool, error)
 
 	// Get value at a given key
 	Get([]byte, NodeResolverFn) ([]byte, error)
@@ -200,6 +200,8 @@ type (
 		// for a steam that isn't present in the tree. This flag is only
 		// true in the context of a stateless tree.
 		isPOAStub bool
+
+		lastEpoch StateEpoch
 	}
 )
 
@@ -266,7 +268,7 @@ func NewStatelessInternal(depth byte, comm *Point) VerkleNode {
 }
 
 // New creates a new leaf node
-func NewLeafNode(stem Stem, values [][]byte) (*LeafNode, error) {
+func NewLeafNode(stem Stem, values [][]byte, lastEpoch StateEpoch) (*LeafNode, error) {
 	cfg := GetConfig()
 
 	// C1.
@@ -309,26 +311,31 @@ func NewLeafNode(stem Stem, values [][]byte) (*LeafNode, error) {
 		return nil, fmt.Errorf("batch mapping to scalar fields: %s", err)
 	}
 
+	// state epoch
+	poly[4].SetUint64(uint64(lastEpoch))
+
 	return &LeafNode{
 		// depth will be 0, but the commitment calculation
 		// does not need it, and so it won't be free.
 		values:     values,
 		stem:       stem,
-		commitment: cfg.CommitToPoly(poly[:], NodeWidth-4),
+		commitment: cfg.CommitToPoly(poly[:], NodeWidth-5),
 		c1:         c1,
 		c2:         c2,
+		lastEpoch:  lastEpoch,
 	}, nil
 }
 
 // NewLeafNodeWithNoComms create a leaf node but does not compute its
 // commitments. The created node's commitments are intended to be
 // initialized with `SetTrustedBytes` in a deserialization context.
-func NewLeafNodeWithNoComms(stem Stem, values [][]byte) *LeafNode {
+func NewLeafNodeWithNoComms(stem Stem, values [][]byte, lastEpoch StateEpoch) *LeafNode {
 	return &LeafNode{
 		// depth will be 0, but the commitment calculation
 		// does not need it, and so it won't be free.
-		values: values,
-		stem:   stem,
+		values:    values,
+		stem:      stem,
+		lastEpoch: lastEpoch,
 	}
 }
 
@@ -358,13 +365,13 @@ func (n *InternalNode) cowChild(index byte) {
 	}
 }
 
-func (n *InternalNode) Insert(key []byte, value []byte, resolver NodeResolverFn) error {
+func (n *InternalNode) Insert(key []byte, value []byte, curEpoch StateEpoch, resolver NodeResolverFn) error {
 	values := make([][]byte, NodeWidth)
 	values[key[StemSize]] = value
-	return n.InsertValuesAtStem(KeyToStem(key), values, resolver)
+	return n.InsertValuesAtStem(KeyToStem(key), values, curEpoch, resolver)
 }
 
-func (n *InternalNode) InsertValuesAtStem(stem Stem, values [][]byte, resolver NodeResolverFn) error {
+func (n *InternalNode) InsertValuesAtStem(stem Stem, values [][]byte, curEpoch StateEpoch, resolver NodeResolverFn) error {
 	nChild := offset2key(stem, n.depth) // index of the child pointed by the next byte in the key
 
 	switch child := n.children[nChild].(type) {
@@ -373,7 +380,7 @@ func (n *InternalNode) InsertValuesAtStem(stem Stem, values [][]byte, resolver N
 	case Empty:
 		n.cowChild(nChild)
 		var err error
-		n.children[nChild], err = NewLeafNode(stem, values)
+		n.children[nChild], err = NewLeafNode(stem, values, curEpoch)
 		if err != nil {
 			return err
 		}
@@ -394,7 +401,7 @@ func (n *InternalNode) InsertValuesAtStem(stem Stem, values [][]byte, resolver N
 		n.cowChild(nChild)
 		// recurse to handle the case of a LeafNode child that
 		// splits.
-		return n.InsertValuesAtStem(stem, values, resolver)
+		return n.InsertValuesAtStem(stem, values, curEpoch, resolver)
 	case *LeafNode:
 		if equalPaths(child.stem, stem) {
 			// We can't insert any values into a POA leaf node.
@@ -402,7 +409,7 @@ func (n *InternalNode) InsertValuesAtStem(stem Stem, values [][]byte, resolver N
 				return errIsPOAStub
 			}
 			n.cowChild(nChild)
-			return child.insertMultiple(stem, values)
+			return child.insertMultiple(stem, values, curEpoch)
 		}
 		n.cowChild(nChild)
 
@@ -418,12 +425,12 @@ func (n *InternalNode) InsertValuesAtStem(stem Stem, values [][]byte, resolver N
 
 		nextWordInInsertedKey := offset2key(stem, n.depth+1)
 		if nextWordInInsertedKey == nextWordInExistingKey {
-			return newBranch.InsertValuesAtStem(stem, values, resolver)
+			return newBranch.InsertValuesAtStem(stem, values, curEpoch, resolver)
 		}
 
 		// Next word differs, so this was the last level.
 		// Insert it directly into its final slot.
-		leaf, err := NewLeafNode(stem, values)
+		leaf, err := NewLeafNode(stem, values, curEpoch)
 		if err != nil {
 			return err
 		}
@@ -432,7 +439,7 @@ func (n *InternalNode) InsertValuesAtStem(stem Stem, values [][]byte, resolver N
 		newBranch.children[nextWordInInsertedKey] = leaf
 	case *InternalNode:
 		n.cowChild(nChild)
-		return child.InsertValuesAtStem(stem, values, resolver)
+		return child.InsertValuesAtStem(stem, values, curEpoch, resolver)
 	default: // It should be an UknownNode.
 		return errUnknownNodeType
 	}
@@ -583,7 +590,7 @@ func (n *InternalNode) GetValuesAtStem(stem Stem, resolver NodeResolverFn) ([][]
 	}
 }
 
-func (n *InternalNode) Delete(key []byte, resolver NodeResolverFn) (bool, error) {
+func (n *InternalNode) Delete(key []byte, curEpoch StateEpoch, resolver NodeResolverFn) (bool, error) {
 	nChild := offset2key(key, n.depth)
 	switch child := n.children[nChild].(type) {
 	case Empty:
@@ -602,10 +609,10 @@ func (n *InternalNode) Delete(key []byte, resolver NodeResolverFn) (bool, error)
 			return false, err
 		}
 		n.children[nChild] = c
-		return n.Delete(key, resolver)
+		return n.Delete(key, curEpoch, resolver)
 	default:
 		n.cowChild(nChild)
-		del, err := child.Delete(key, resolver)
+		del, err := child.Delete(key, curEpoch, resolver)
 		if err != nil {
 			return false, err
 		}
@@ -846,7 +853,6 @@ func (n *InternalNode) Commit() *Point {
 						// TODO: make Commit() return an error
 						panic(err)
 					}
-
 				}()
 			}
 			wg.Wait()
@@ -1146,7 +1152,7 @@ func (n *InternalNode) touchCoW(index byte) {
 	n.cowChild(index)
 }
 
-func (n *LeafNode) Insert(key []byte, value []byte, _ NodeResolverFn) error {
+func (n *LeafNode) Insert(key []byte, value []byte, curEpoch StateEpoch, _ NodeResolverFn) error {
 	if n.isPOAStub {
 		return errIsPOAStub
 	}
@@ -1161,16 +1167,20 @@ func (n *LeafNode) Insert(key []byte, value []byte, _ NodeResolverFn) error {
 	}
 	values := make([][]byte, NodeWidth)
 	values[key[StemSize]] = value
-	return n.insertMultiple(stem, values)
+	return n.insertMultiple(stem, values, curEpoch)
 }
 
-func (n *LeafNode) insertMultiple(stem Stem, values [][]byte) error {
+func (n *LeafNode) insertMultiple(stem Stem, values [][]byte, curEpoch StateEpoch) error {
 	// Sanity check: ensure the stems are the same.
 	if !equalPaths(stem, n.stem) {
 		return errInsertIntoOtherStem
 	}
 
-	return n.updateMultipleLeaves(values)
+	if err := n.updateMultipleLeaves(values, curEpoch); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (n *LeafNode) updateC(cxIndex int, newC Fr, oldC Fr) {
@@ -1250,7 +1260,7 @@ func (n *LeafNode) updateLeaf(index byte, value []byte) error {
 	return nil
 }
 
-func (n *LeafNode) updateMultipleLeaves(values [][]byte) error { // skipcq: GO-R1005
+func (n *LeafNode) updateMultipleLeaves(values [][]byte, curEpoch StateEpoch) error { // skipcq: GO-R1005
 	var oldC1, oldC2 *Point
 
 	// We iterate the values, and we update the C1 and/or C2 commitments depending on the index.
@@ -1298,16 +1308,19 @@ func (n *LeafNode) updateMultipleLeaves(values [][]byte) error { // skipcq: GO-R
 		}
 		n.updateC(c1Idx, frs[0], frs[1])
 		n.updateC(c2Idx, frs[2], frs[3])
+		n.lastEpoch = curEpoch
 	} else if oldC1 != nil { // Case 2. (C1 touched)
 		if err := banderwagon.BatchMapToScalarField([]*Fr{&frs[0], &frs[1]}, []*Point{n.c1, oldC1}); err != nil {
 			return fmt.Errorf("batch mapping to scalar fields: %s", err)
 		}
 		n.updateC(c1Idx, frs[0], frs[1])
+		n.lastEpoch = curEpoch
 	} else if oldC2 != nil { // Case 2. (C2 touched)
 		if err := banderwagon.BatchMapToScalarField([]*Fr{&frs[0], &frs[1]}, []*Point{n.c2, oldC2}); err != nil {
 			return fmt.Errorf("batch mapping to scalar fields: %s", err)
 		}
 		n.updateC(c2Idx, frs[0], frs[1])
+		n.lastEpoch = curEpoch
 	}
 
 	return nil
@@ -1315,7 +1328,7 @@ func (n *LeafNode) updateMultipleLeaves(values [][]byte) error { // skipcq: GO-R
 
 // Delete deletes a value from the leaf, return `true` as a second
 // return value, if the parent should entirely delete the child.
-func (n *LeafNode) Delete(k []byte, _ NodeResolverFn) (bool, error) {
+func (n *LeafNode) Delete(k []byte, curEpoch StateEpoch, _ NodeResolverFn) (bool, error) {
 	// Sanity check: ensure the key header is the same:
 	if !equalPaths(k, n.stem) {
 		return false, nil
@@ -1642,7 +1655,7 @@ func (n *LeafNode) GetProofItems(keys keylist, _ NodeResolverFn) (*ProofElements
 }
 
 // Serialize serializes a LeafNode.
-// The format is: <nodeType><stem><bitlist><comm><c1comm><c2comm><children...>
+// The format is: <nodeType><stem><bitlist><comm><c1comm><c2comm><lastEpoch><children...>
 func (n *LeafNode) Serialize() ([]byte, error) {
 	cBytes := banderwagon.BatchToBytesUncompressed(n.commitment, n.c1, n.c2)
 	return n.serializeLeafWithUncompressedCommitments(cBytes[0], cBytes[1], cBytes[2]), nil
@@ -1885,6 +1898,7 @@ func (n *LeafNode) serializeLeafWithUncompressedCommitments(cBytes, c1Bytes, c2B
 
 	// Create the serialization.
 	var result []byte
+	lastEpoch := n.lastEpoch.Bytes()
 	switch {
 	case count == 1:
 		var buf [singleSlotLeafSize]byte
@@ -1893,8 +1907,9 @@ func (n *LeafNode) serializeLeafWithUncompressedCommitments(cBytes, c1Bytes, c2B
 		copy(result[leafStemOffset:], n.stem[:StemSize])
 		copy(result[leafStemOffset+StemSize:], c1Bytes[:])
 		copy(result[leafStemOffset+StemSize+banderwagon.UncompressedSize:], cBytes[:])
-		result[leafStemOffset+StemSize+2*banderwagon.UncompressedSize] = byte(lastIdx)
-		copy(result[leafStemOffset+StemSize+2*banderwagon.UncompressedSize+leafValueIndexSize:], n.values[lastIdx][:])
+		copy(result[leafStemOffset+StemSize+2*banderwagon.UncompressedSize:], lastEpoch)
+		result[leafStemOffset+StemSize+2*banderwagon.UncompressedSize+EpochSize] = byte(lastIdx)
+		copy(result[leafStemOffset+StemSize+2*banderwagon.UncompressedSize+EpochSize+leafValueIndexSize:], n.values[lastIdx][:])
 	case isEoA:
 		var buf [eoaLeafSize]byte
 		result = buf[:]
@@ -1902,16 +1917,18 @@ func (n *LeafNode) serializeLeafWithUncompressedCommitments(cBytes, c1Bytes, c2B
 		copy(result[leafStemOffset:], n.stem[:StemSize])
 		copy(result[leafStemOffset+StemSize:], c1Bytes[:])
 		copy(result[leafStemOffset+StemSize+banderwagon.UncompressedSize:], cBytes[:])
-		copy(result[leafStemOffset+StemSize+2*banderwagon.UncompressedSize:], n.values[1])                                 // copy balance
-		copy(result[leafStemOffset+StemSize+2*banderwagon.UncompressedSize+leafBalanceSize:], n.values[2][:leafNonceSize]) // copy nonce
+		copy(result[leafStemOffset+StemSize+2*banderwagon.UncompressedSize:], lastEpoch)
+		copy(result[leafStemOffset+StemSize+2*banderwagon.UncompressedSize+EpochSize:], n.values[1])                                 // copy balance
+		copy(result[leafStemOffset+StemSize+2*banderwagon.UncompressedSize+EpochSize+leafBalanceSize:], n.values[2][:leafNonceSize]) // copy nonce
 	default:
-		result = make([]byte, nodeTypeSize+StemSize+bitlistSize+3*banderwagon.UncompressedSize+len(children))
+		result = make([]byte, nodeTypeSize+StemSize+bitlistSize+3*banderwagon.UncompressedSize+EpochSize+len(children))
 		result[0] = leafType
 		copy(result[leafStemOffset:], n.stem[:StemSize])
 		copy(result[leafBitlistOffset:], bitlist[:])
 		copy(result[leafCommitmentOffset:], cBytes[:])
 		copy(result[leafC1CommitmentOffset:], c1Bytes[:])
 		copy(result[leafC2CommitmentOffset:], c2Bytes[:])
+		copy(result[leafLastEpochOffset:], lastEpoch)
 		copy(result[leafChildrenOffset:], children)
 	}
 

--- a/tree_ipa_test.go
+++ b/tree_ipa_test.go
@@ -85,7 +85,7 @@ func TestInsertKey0Value0(t *testing.T) {
 		srs       = cfg.conf.SRS
 	)
 
-	if err := root.Insert(zeroKeyTest, zeroKeyTest, nil); err != nil {
+	if err := root.Insert(zeroKeyTest, zeroKeyTest, 0, nil); err != nil {
 		t.Fatalf("insert failed: %s", err)
 	}
 	comm := root.Commit()
@@ -118,7 +118,7 @@ func TestInsertKey1Value1(t *testing.T) {
 		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
 		25, 26, 27, 28, 29, 30, 31, 32,
 	}
-	if err := root.Insert(key, key, nil); err != nil {
+	if err := root.Insert(key, key, 0, nil); err != nil {
 		t.Fatalf("insert failed: %s", err)
 	}
 	comm := root.Commit()
@@ -156,10 +156,10 @@ func TestInsertSameStemTwoLeaves(t *testing.T) {
 		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
 		25, 26, 27, 28, 29, 30, 31, 128,
 	}
-	if err := root.Insert(key_a, key_a, nil); err != nil {
+	if err := root.Insert(key_a, key_a, 0, nil); err != nil {
 		t.Fatalf("insert failed: %s", err)
 	}
-	if err := root.Insert(key_b, key_b, nil); err != nil {
+	if err := root.Insert(key_b, key_b, 0, nil); err != nil {
 		t.Fatalf("insert failed: %s", err)
 	}
 	comm := root.Commit()
@@ -211,10 +211,10 @@ func TestInsertKey1Val1Key2Val2(t *testing.T) {
 		srs                 = cfg.conf.SRS
 	)
 	key_b, _ := hex.DecodeString("0101010101010101010101010101010101010101010101010101010101010101")
-	if err := root.Insert(zeroKeyTest, zeroKeyTest, nil); err != nil {
+	if err := root.Insert(zeroKeyTest, zeroKeyTest, 0, nil); err != nil {
 		t.Fatalf("insert failed: %s", err)
 	}
-	if err := root.Insert(key_b, key_b, nil); err != nil {
+	if err := root.Insert(key_b, key_b, 0, nil); err != nil {
 		t.Fatalf("insert failed: %s", err)
 	}
 	comm := root.Commit()

--- a/tree_test.go
+++ b/tree_test.go
@@ -61,7 +61,7 @@ func TestInsertIntoRoot(t *testing.T) {
 	t.Parallel()
 
 	root := New()
-	if err := root.Insert(zeroKeyTest, testValue, nil); err != nil {
+	if err := root.Insert(zeroKeyTest, testValue, 0, nil); err != nil {
 		t.Fatalf("error inserting: %v", err)
 	}
 
@@ -79,10 +79,10 @@ func TestInsertTwoLeaves(t *testing.T) {
 	t.Parallel()
 
 	root := New()
-	if err := root.Insert(zeroKeyTest, testValue, nil); err != nil {
+	if err := root.Insert(zeroKeyTest, testValue, 0, nil); err != nil {
 		t.Fatalf("error inserting: %v", err)
 	}
-	if err := root.Insert(ffx32KeyTest, testValue, nil); err != nil {
+	if err := root.Insert(ffx32KeyTest, testValue, 0, nil); err != nil {
 		t.Fatalf("error inserting: %v", err)
 	}
 
@@ -109,10 +109,10 @@ func TestInsertTwoLeavesLastLevel(t *testing.T) {
 	t.Parallel()
 
 	root := New()
-	if err := root.Insert(zeroKeyTest, testValue, nil); err != nil {
+	if err := root.Insert(zeroKeyTest, testValue, 0, nil); err != nil {
 		t.Fatalf("error inserting: %v", err)
 	}
-	if err := root.Insert(oneKeyTest, testValue, nil); err != nil {
+	if err := root.Insert(oneKeyTest, testValue, 0, nil); err != nil {
 		t.Fatalf("error inserting: %v", err)
 	}
 
@@ -133,10 +133,10 @@ func TestGetTwoLeaves(t *testing.T) {
 	t.Parallel()
 
 	root := New()
-	if err := root.Insert(zeroKeyTest, testValue, nil); err != nil {
+	if err := root.Insert(zeroKeyTest, testValue, 0, nil); err != nil {
 		t.Fatalf("error inserting: %v", err)
 	}
-	if err := root.Insert(ffx32KeyTest, testValue, nil); err != nil {
+	if err := root.Insert(ffx32KeyTest, testValue, 0, nil); err != nil {
 		t.Fatalf("error inserting: %v", err)
 	}
 
@@ -187,7 +187,7 @@ func TestFlush1kLeaves(t *testing.T) {
 	go func() {
 		root := New()
 		for _, k := range keys {
-			if err := root.Insert(k, fourtyKeyTest, nil); err != nil {
+			if err := root.Insert(k, fourtyKeyTest, 0, nil); err != nil {
 				panic(err)
 			}
 		}
@@ -221,17 +221,17 @@ func TestCopy(t *testing.T) {
 	key2, _ := hex.DecodeString("0107000000000000000000000000000000000000000000000000000000000000")
 	key3, _ := hex.DecodeString("0405000000000000000000000000000000000000000000000000000000000000")
 	tree := New()
-	if err := tree.Insert(key1, fourtyKeyTest, nil); err != nil {
+	if err := tree.Insert(key1, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into the original failed: %v", err)
 	}
-	if err := tree.Insert(key2, fourtyKeyTest, nil); err != nil {
+	if err := tree.Insert(key2, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into the original failed: %v", err)
 	}
 	tree.Commit()
 
 	copied := tree.Copy()
 
-	if err := tree.Insert(key3, fourtyKeyTest, nil); err != nil {
+	if err := tree.Insert(key3, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into the original failed: %v", err)
 	}
 
@@ -239,7 +239,7 @@ func TestCopy(t *testing.T) {
 		t.Fatal("inserting the copy into the original tree updated the copy's commitment")
 	}
 
-	if err := copied.Insert(key3, fourtyKeyTest, nil); err != nil {
+	if err := copied.Insert(key3, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into the copy failed: %v", err)
 	}
 
@@ -256,13 +256,13 @@ func TestCachedCommitment(t *testing.T) {
 	key3, _ := hex.DecodeString("0405000000000000000000000000000000000000000000000000000000000000")
 	key4, _ := hex.DecodeString("0407000000000000000000000000000000000000000000000000000000000000")
 	tree := New()
-	if err := tree.Insert(key1, fourtyKeyTest, nil); err != nil {
+	if err := tree.Insert(key1, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into the original failed: %v", err)
 	}
-	if err := tree.Insert(key2, fourtyKeyTest, nil); err != nil {
+	if err := tree.Insert(key2, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into the original failed: %v", err)
 	}
-	if err := tree.Insert(key3, fourtyKeyTest, nil); err != nil {
+	if err := tree.Insert(key3, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into the original failed: %v", err)
 	}
 	oldRoot := tree.Commit().Bytes()
@@ -272,7 +272,7 @@ func TestCachedCommitment(t *testing.T) {
 		t.Error("root has not cached commitment")
 	}
 
-	if err := tree.Insert(key4, fourtyKeyTest, nil); err != nil {
+	if err := tree.Insert(key4, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into key4 failed: %v", err)
 	}
 	tree.Commit()
@@ -297,25 +297,25 @@ func TestDelLeaf(t *testing.T) { // skipcq: GO-R1005
 	key2, _ := hex.DecodeString("0107000000000000000000000000000000000000000000000000000000000000")
 	key3, _ := hex.DecodeString("0405000000000000000000000000000000000000000000000000000000000000")
 	tree := New()
-	if err := tree.Insert(key1, fourtyKeyTest, nil); err != nil {
+	if err := tree.Insert(key1, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into the original failed: %v", err)
 	}
-	if err := tree.Insert(key1p, fourtyKeyTest, nil); err != nil {
+	if err := tree.Insert(key1p, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into the original failed: %v", err)
 	}
-	if err := tree.Insert(key1pp, fourtyKeyTest, nil); err != nil {
+	if err := tree.Insert(key1pp, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into the original failed: %v", err)
 	}
-	if err := tree.Insert(key2, fourtyKeyTest, nil); err != nil {
+	if err := tree.Insert(key2, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into the original failed: %v", err)
 	}
 	var init Point
 	init.Set(tree.Commit())
 
-	if err := tree.Insert(key3, fourtyKeyTest, nil); err != nil {
+	if err := tree.Insert(key3, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into the original failed: %v", err)
 	}
-	if _, err := tree.Delete(key3, nil); err != nil {
+	if _, err := tree.Delete(key3, 0, nil); err != nil {
 		t.Error(err)
 	}
 
@@ -335,7 +335,7 @@ func TestDelLeaf(t *testing.T) { // skipcq: GO-R1005
 		t.Error("leaf hasnt been deleted")
 	}
 
-	if _, err := tree.Delete(key1pp, nil); err != nil {
+	if _, err := tree.Delete(key1pp, 0, nil); err != nil {
 		t.Fatal(err)
 	}
 	res, err = tree.Get(key1pp, nil)
@@ -346,7 +346,7 @@ func TestDelLeaf(t *testing.T) { // skipcq: GO-R1005
 		t.Error("leaf hasnt been deleted")
 	}
 
-	if _, err := tree.Delete(key1p, nil); err != nil {
+	if _, err := tree.Delete(key1p, 0, nil); err != nil {
 		t.Fatal(err)
 	}
 	res, err = tree.Get(key1p, nil)
@@ -366,16 +366,16 @@ func TestDeleteAtStem(t *testing.T) {
 	key1pp, _ := hex.DecodeString("0105000000000000000000000000000000000000000000000000000000000081") // Other Cn group as key1
 	key2, _ := hex.DecodeString("0107000000000000000000000000000000000000000000000000000000000000")
 	tree := New()
-	if err := tree.Insert(key1, fourtyKeyTest, nil); err != nil {
+	if err := tree.Insert(key1, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into the original failed: %v", err)
 	}
-	if err := tree.Insert(key1p, fourtyKeyTest, nil); err != nil {
+	if err := tree.Insert(key1p, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into the original failed: %v", err)
 	}
-	if err := tree.Insert(key1pp, fourtyKeyTest, nil); err != nil {
+	if err := tree.Insert(key1pp, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into the original failed: %v", err)
 	}
-	if err := tree.Insert(key2, fourtyKeyTest, nil); err != nil {
+	if err := tree.Insert(key2, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into the original failed: %v", err)
 	}
 	var init Point
@@ -412,13 +412,13 @@ func TestDeleteNonExistent(t *testing.T) {
 	key2, _ := hex.DecodeString("0107000000000000000000000000000000000000000000000000000000000000")
 	key3, _ := hex.DecodeString("0405000000000000000000000000000000000000000000000000000000000000")
 	tree := New()
-	if err := tree.Insert(key1, fourtyKeyTest, nil); err != nil {
+	if err := tree.Insert(key1, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into key1 failed: %v", err)
 	}
-	if err := tree.Insert(key2, fourtyKeyTest, nil); err != nil {
+	if err := tree.Insert(key2, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into key2 failed: %v", err)
 	}
-	if _, err := tree.Delete(key3, nil); err != nil {
+	if _, err := tree.Delete(key3, 0, nil); err != nil {
 		t.Error("should not fail when deleting a non-existent key")
 	}
 }
@@ -432,29 +432,29 @@ func TestDeletePrune(t *testing.T) { // skipcq: GO-R1005
 	key4, _ := hex.DecodeString("0407000000000000000000000000000000000000000000000000000000000000")
 	key5, _ := hex.DecodeString("04070000000000000000000000000000000000000000000000000000000000FF")
 	tree := New()
-	if err := tree.Insert(key1, fourtyKeyTest, nil); err != nil {
+	if err := tree.Insert(key1, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into key1 failed: %v", err)
 	}
-	if err := tree.Insert(key2, fourtyKeyTest, nil); err != nil {
+	if err := tree.Insert(key2, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into key2 failed: %v", err)
 	}
 
 	var hashPostKey2, hashPostKey4, completeTreeHash Point
 	hashPostKey2.Set(tree.Commit())
-	if err := tree.Insert(key3, fourtyKeyTest, nil); err != nil {
+	if err := tree.Insert(key3, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into key3 failed: %v", err)
 	}
-	if err := tree.Insert(key4, fourtyKeyTest, nil); err != nil {
+	if err := tree.Insert(key4, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into key4 failed: %v", err)
 	}
 	hashPostKey4.Set(tree.Commit())
-	if err := tree.Insert(key5, fourtyKeyTest, nil); err != nil {
+	if err := tree.Insert(key5, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into key5 failed: %v", err)
 	}
 	completeTreeHash.Set(tree.Commit()) // hash when the tree has received all its keys
 
 	// Delete key5.
-	if _, err := tree.Delete(key5, nil); err != nil {
+	if _, err := tree.Delete(key5, 0, nil); err != nil {
 		t.Error(err)
 	}
 	postHash := tree.Commit()
@@ -476,10 +476,10 @@ func TestDeletePrune(t *testing.T) { // skipcq: GO-R1005
 	}
 
 	// Delete key4 and key3.
-	if _, err := tree.Delete(key4, nil); err != nil {
+	if _, err := tree.Delete(key4, 0, nil); err != nil {
 		t.Error(err)
 	}
-	if _, err := tree.Delete(key3, nil); err != nil {
+	if _, err := tree.Delete(key3, 0, nil); err != nil {
 		t.Error(err)
 	}
 	postHash = tree.Commit()
@@ -500,25 +500,25 @@ func TestDeletePrune(t *testing.T) { // skipcq: GO-R1005
 // their hashed values. It then tries to delete the hashed values, which should
 // fail.
 func TestDeleteHash(t *testing.T) {
-	//TODO: fix this test when we take a final decision about FlushAtDepth API.
+	// TODO: fix this test when we take a final decision about FlushAtDepth API.
 	t.SkipNow()
 
 	key1, _ := hex.DecodeString("0105000000000000000000000000000000000000000000000000000000000000")
 	key2, _ := hex.DecodeString("0107000000000000000000000000000000000000000000000000000000000000")
 	key3, _ := hex.DecodeString("0405000000000000000000000000000000000000000000000000000000000000")
 	tree := New()
-	if err := tree.Insert(key1, fourtyKeyTest, nil); err != nil {
+	if err := tree.Insert(key1, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into key1 failed: %v", err)
 	}
-	if err := tree.Insert(key2, fourtyKeyTest, nil); err != nil {
+	if err := tree.Insert(key2, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into key2 failed: %v", err)
 	}
-	if err := tree.Insert(key3, fourtyKeyTest, nil); err != nil {
+	if err := tree.Insert(key3, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into key3 failed: %v", err)
 	}
 	tree.(*InternalNode).FlushAtDepth(0, func(path []byte, vn VerkleNode) {})
 	tree.Commit()
-	if _, err := tree.Delete(key2, nil); err != errDeleteHash {
+	if _, err := tree.Delete(key2, 0, nil); err != errDeleteHash {
 		t.Fatalf("did not report the correct error while deleting from a hash: %v", err)
 	}
 }
@@ -530,21 +530,21 @@ func TestDeleteUnequalPath(t *testing.T) {
 	key2, _ := hex.DecodeString("0107000000000000000000000000000000000000000000000000000000000000")
 	key3, _ := hex.DecodeString("0405000000000000000000000000000000000000000000000000000000000000")
 	tree := New()
-	if err := tree.Insert(key1, fourtyKeyTest, nil); err != nil {
+	if err := tree.Insert(key1, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into key1 failed: %v", err)
 	}
-	if err := tree.Insert(key3, fourtyKeyTest, nil); err != nil {
+	if err := tree.Insert(key3, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into key3 failed: %v", err)
 	}
 	tree.Commit()
 
-	if _, err := tree.Delete(key2, nil); err != nil {
+	if _, err := tree.Delete(key2, 0, nil); err != nil {
 		t.Fatalf("errored during the deletion of non-existing key, err =%v", err)
 	}
 }
 
 func TestDeleteResolve(t *testing.T) {
-	//TODO: fix this test when we take a final decision about FlushAtDepth API.
+	// TODO: fix this test when we take a final decision about FlushAtDepth API.
 	t.SkipNow()
 
 	key1, _ := hex.DecodeString("0105000000000000000000000000000000000000000000000000000000000000")
@@ -555,20 +555,20 @@ func TestDeleteResolve(t *testing.T) {
 	saveNode := func(path []byte, node VerkleNode) {
 		savedNodes[string(path)] = node
 	}
-	if err := tree.Insert(key1, fourtyKeyTest, nil); err != nil {
+	if err := tree.Insert(key1, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into key1 failed: %v", err)
 	}
-	if err := tree.Insert(key2, fourtyKeyTest, nil); err != nil {
+	if err := tree.Insert(key2, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into key2 failed: %v", err)
 	}
-	if err := tree.Insert(key3, fourtyKeyTest, nil); err != nil {
+	if err := tree.Insert(key3, fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into key3 failed: %v", err)
 	}
 	tree.(*InternalNode).FlushAtDepth(0, saveNode)
 	tree.Commit()
 
 	var called bool
-	_, err := tree.Delete(key2, func(path []byte) ([]byte, error) {
+	_, err := tree.Delete(key2, 0, func(path []byte) ([]byte, error) {
 		called = true
 
 		if node, ok := savedNodes[string(path)]; ok {
@@ -590,7 +590,7 @@ func TestConcurrentTrees(t *testing.T) {
 	t.Parallel()
 
 	tree := New()
-	err := tree.Insert(zeroKeyTest, fourtyKeyTest, nil)
+	err := tree.Insert(zeroKeyTest, fourtyKeyTest, 0, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -600,7 +600,7 @@ func TestConcurrentTrees(t *testing.T) {
 	ch := make(chan *Point)
 	builder := func() {
 		tree := New()
-		if err := tree.Insert(zeroKeyTest, fourtyKeyTest, nil); err != nil {
+		if err := tree.Insert(zeroKeyTest, fourtyKeyTest, 0, nil); err != nil {
 			panic(err)
 		}
 		ch <- tree.Commit()
@@ -637,7 +637,7 @@ func BenchmarkCommitFullNode(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		root := New()
 		for _, k := range keys {
-			if err := root.Insert(k, fourtyKeyTest, nil); err != nil {
+			if err := root.Insert(k, fourtyKeyTest, 0, nil); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -679,7 +679,7 @@ func benchmarkCommitNLeaves(b *testing.B, n int) {
 		for i := 0; i < b.N; i++ {
 			root := New()
 			for _, el := range kvs {
-				if err := root.Insert(el.k, el.v, nil); err != nil {
+				if err := root.Insert(el.k, el.v, 0, nil); err != nil {
 					b.Error(err)
 				}
 			}
@@ -700,7 +700,7 @@ func BenchmarkModifyLeaves(b *testing.B) {
 			b.Fatalf("failed to generate random key: %v", err)
 		}
 		keys[i] = key
-		if err := root.Insert(key, val, nil); err != nil {
+		if err := root.Insert(key, val, 0, nil); err != nil {
 			b.Fatalf("inserting into key1 failed: %v", err)
 		}
 	}
@@ -714,7 +714,7 @@ func BenchmarkModifyLeaves(b *testing.B) {
 		binary.BigEndian.PutUint32(val, uint32(i))
 		for j := 0; j < toEdit; j++ {
 			k := keys[mRand.IntN(n)]
-			if err := root.Insert(k, val, nil); err != nil {
+			if err := root.Insert(k, val, 0, nil); err != nil {
 				b.Error(err)
 			}
 		}
@@ -744,10 +744,10 @@ func TestNodeSerde(t *testing.T) {
 	t.Parallel()
 
 	tree := New()
-	if err := tree.Insert(zeroKeyTest, testValue, nil); err != nil {
+	if err := tree.Insert(zeroKeyTest, testValue, 0, nil); err != nil {
 		t.Fatalf("inserting into key1 failed: %v", err)
 	}
-	if err := tree.Insert(fourtyKeyTest, testValue, nil); err != nil {
+	if err := tree.Insert(fourtyKeyTest, testValue, 0, nil); err != nil {
 		t.Fatalf("inserting into key2 failed: %v", err)
 	}
 	origComm := tree.Commit().BytesUncompressedTrusted()
@@ -851,7 +851,7 @@ func isLeafEqual(a, b *LeafNode) bool {
 }
 
 func TestGetResolveFromHash(t *testing.T) {
-	//TODO: fix this test when we take a final decision about FlushAtDepth API.
+	// TODO: fix this test when we take a final decision about FlushAtDepth API.
 	t.SkipNow()
 
 	var count uint
@@ -873,14 +873,14 @@ func TestGetResolveFromHash(t *testing.T) {
 		serialized = append(serialized, s...)
 	}
 	root := New()
-	if err := root.Insert(zeroKeyTest, zeroKeyTest, nil); err != nil {
+	if err := root.Insert(zeroKeyTest, zeroKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into the original failed: %v", err)
 	}
-	if err := root.Insert(fourtyKeyTest, zeroKeyTest, nil); err != nil {
+	if err := root.Insert(fourtyKeyTest, zeroKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into the original failed: %v", err)
 	}
 	root.(*InternalNode).FlushAtDepth(0, flush)
-	if err := root.Insert(oneKeyTest, zeroKeyTest, nil); err != errInsertIntoHash {
+	if err := root.Insert(oneKeyTest, zeroKeyTest, 0, nil); err != errInsertIntoHash {
 		t.Fatal(err)
 	}
 
@@ -926,30 +926,30 @@ func TestGetKey(t *testing.T) {
 }
 
 func TestInsertIntoHashedNode(t *testing.T) {
-	//TODO: fix this test when we take a final decision about FlushAtDepth API.
+	// TODO: fix this test when we take a final decision about FlushAtDepth API.
 	t.SkipNow()
 
 	root := New()
-	if err := root.Insert(zeroKeyTest, zeroKeyTest, nil); err != nil {
+	if err := root.Insert(zeroKeyTest, zeroKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into the original failed: %v", err)
 	}
 	root.(*InternalNode).FlushAtDepth(0, func(_ []byte, n VerkleNode) {})
-	if err := root.Insert(fourtyKeyTest, zeroKeyTest, nil); err != nil {
+	if err := root.Insert(fourtyKeyTest, zeroKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into the original failed: %v", err)
 	}
 
-	if err := root.Insert(zeroKeyTest, zeroKeyTest, nil); err != errInsertIntoHash {
+	if err := root.Insert(zeroKeyTest, zeroKeyTest, 0, nil); err != errInsertIntoHash {
 		t.Fatalf("incorrect error type: %v", err)
 	}
 
 	resolver := func(h []byte) ([]byte, error) {
 		values := make([][]byte, NodeWidth)
 		values[0] = zeroKeyTest
-		node, _ := NewLeafNode(KeyToStem(zeroKeyTest), values)
+		node, _ := NewLeafNode(KeyToStem(zeroKeyTest), values, 0)
 
 		return node.Serialize()
 	}
-	if err := root.Copy().Insert(zeroKeyTest, zeroKeyTest, resolver); err != nil {
+	if err := root.Copy().Insert(zeroKeyTest, zeroKeyTest, 0, resolver); err != nil {
 		t.Fatalf("error in node resolution: %v", err)
 	}
 
@@ -958,12 +958,12 @@ func TestInsertIntoHashedNode(t *testing.T) {
 	invalidRLPResolver := func(h []byte) ([]byte, error) {
 		values := make([][]byte, NodeWidth)
 		values[0] = zeroKeyTest
-		node, _ := NewLeafNode(KeyToStem(zeroKeyTest), values)
+		node, _ := NewLeafNode(KeyToStem(zeroKeyTest), values, 0)
 
 		rlp, _ := node.Serialize()
 		return rlp[:len(rlp)-10], nil
 	}
-	if err := root.Copy().Insert(zeroKeyTest, zeroKeyTest, invalidRLPResolver); !errors.Is(err, errSerializedPayloadTooShort) {
+	if err := root.Copy().Insert(zeroKeyTest, zeroKeyTest, 0, invalidRLPResolver); !errors.Is(err, errSerializedPayloadTooShort) {
 		t.Fatalf("error detecting a decoding error after resolution: %v", err)
 	}
 
@@ -972,23 +972,23 @@ func TestInsertIntoHashedNode(t *testing.T) {
 	erroringResolver := func(h []byte) ([]byte, error) {
 		return nil, randomResolverError
 	}
-	if err := root.Copy().Insert(zeroKeyTest, zeroKeyTest, erroringResolver); !errors.Is(err, randomResolverError) {
+	if err := root.Copy().Insert(zeroKeyTest, zeroKeyTest, 0, erroringResolver); !errors.Is(err, randomResolverError) {
 		t.Fatalf("error detecting a resolution error: %v", err)
 	}
 }
 
 func TestToDot(t *testing.T) {
 	root := New()
-	if err := root.Insert(zeroKeyTest, zeroKeyTest, nil); err != nil {
+	if err := root.Insert(zeroKeyTest, zeroKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into the original failed: %v", err)
 	}
 	// TODO fix the issue with FlushAtDepth so that we can also try to verify the display of hashed nodes
 	// root.(*InternalNode).FlushAtDepth(0, func(_ []byte, n VerkleNode) {}) // Hash the leaf to ensure HashedNodes display correctly
-	if err := root.Insert(fourtyKeyTest, zeroKeyTest, nil); err != nil {
+	if err := root.Insert(fourtyKeyTest, zeroKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into the original failed: %v", err)
 	}
 	fourtytwoKeyTest, _ := hex.DecodeString("4020000000000000000000000000000000000000000000000000000000000000")
-	if err := root.Insert(fourtytwoKeyTest, zeroKeyTest, nil); err != nil {
+	if err := root.Insert(fourtytwoKeyTest, zeroKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into the original failed: %v", err)
 	}
 
@@ -1021,7 +1021,7 @@ func TestEmptyCommitment(t *testing.T) {
 	t.Parallel()
 
 	root := New()
-	if err := root.Insert(zeroKeyTest, zeroKeyTest, nil); err != nil {
+	if err := root.Insert(zeroKeyTest, zeroKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into the original failed: %v", err)
 	}
 	root.Commit()
@@ -1083,7 +1083,7 @@ func TestGetProofItemsNoPoaIfStemPresent(t *testing.T) {
 	t.Parallel()
 
 	root := New()
-	if err := root.Insert(ffx32KeyTest, zeroKeyTest, nil); err != nil {
+	if err := root.Insert(ffx32KeyTest, zeroKeyTest, 0, nil); err != nil {
 		t.Fatalf("inserting into the original failed: %v", err)
 	}
 
@@ -1128,7 +1128,7 @@ func TestWithRustCompatibility(t *testing.T) {
 
 	root := New()
 	for i, key := range testAccountKeys {
-		err := root.Insert(key, testAccountValues[i], nil)
+		err := root.Insert(key, testAccountValues[i], 0, nil)
 		if err != nil {
 			t.Fatalf("error inserting: %v", err)
 		}
@@ -1150,7 +1150,7 @@ func TestInsertStem(t *testing.T) {
 	values[5] = zeroKeyTest
 	values[192] = fourtyKeyTest
 
-	if err := root1.(*InternalNode).InsertValuesAtStem(KeyToStem(fourtyKeyTest), values, nil); err != nil {
+	if err := root1.(*InternalNode).InsertValuesAtStem(KeyToStem(fourtyKeyTest), values, 0, nil); err != nil {
 		t.Fatalf("error inserting: %s", err)
 	}
 	r1c := root1.Commit()
@@ -1160,10 +1160,10 @@ func TestInsertStem(t *testing.T) {
 	copy(key192[:], KeyToStem(fourtyKeyTest))
 	key5[StemSize] = 5
 	key192[StemSize] = 192
-	if err := root2.Insert(key5[:], zeroKeyTest, nil); err != nil {
+	if err := root2.Insert(key5[:], zeroKeyTest, 0, nil); err != nil {
 		t.Fatalf("error inserting: %s", err)
 	}
-	if err := root2.Insert(key192[:], fourtyKeyTest, nil); err != nil {
+	if err := root2.Insert(key192[:], fourtyKeyTest, 0, nil); err != nil {
 		t.Fatalf("error inserting: %s", err)
 	}
 	r2c := root2.Commit()
@@ -1179,7 +1179,7 @@ func TestInsertStemTouchingBothHalves(t *testing.T) {
 	root := New()
 
 	// Insert keys such that both C1 and C2 have values.
-	if err := root.Insert(zeroKeyTest, testValue, nil); err != nil {
+	if err := root.Insert(zeroKeyTest, testValue, 0, nil); err != nil {
 		t.Fatalf("error inserting: %v", err)
 	}
 	zeroKeyTest2 := append([]byte{}, zeroKeyTest...)
@@ -1198,7 +1198,7 @@ func TestInsertStemTouchingBothHalves(t *testing.T) {
 	newValues := make([][]byte, NodeWidth)
 	newValues[1] = testValue
 	newValues[NodeWidth-2] = testValue
-	if err := root.(*InternalNode).InsertValuesAtStem(KeyToStem(zeroKeyTest), newValues, nil); err != nil {
+	if err := root.(*InternalNode).InsertValuesAtStem(KeyToStem(zeroKeyTest), newValues, 0, nil); err != nil {
 		t.Fatalf("error inserting stem: %v", err)
 	}
 	root.Commit()
@@ -1215,7 +1215,7 @@ func TestInsertResolveSplitLeaf(t *testing.T) {
 
 	// Insert a unique leaf and flush it
 	root := New()
-	if err := root.Insert(zeroKeyTest, ffx32KeyTest, nil); err != nil {
+	if err := root.Insert(zeroKeyTest, ffx32KeyTest, 0, nil); err != nil {
 		t.Fatalf("error inserting: %v", err)
 	}
 	root.(*InternalNode).Flush(func(_ []byte, node VerkleNode) {
@@ -1237,7 +1237,7 @@ func TestInsertResolveSplitLeaf(t *testing.T) {
 
 	// Now insert another leaf, with a resolver function
 	key, _ := hex.DecodeString("0000100000000000000000000000000000000000000000000000000000000000")
-	if err := root.Insert(key, ffx32KeyTest, func(path []byte) ([]byte, error) {
+	if err := root.Insert(key, ffx32KeyTest, 0, func(path []byte) ([]byte, error) {
 		if len(path) != int(leaf.depth) {
 			return nil, fmt.Errorf("invalid path length: %d != %d", len(path), leaf.depth)
 		}
@@ -1331,7 +1331,7 @@ func TestRustBanderwagonBlock48(t *testing.T) {
 		}
 
 		v, _ := hex.DecodeString(s)
-		if err := tree.Insert(keys[i], v, nil); err != nil {
+		if err := tree.Insert(keys[i], v, 0, nil); err != nil {
 			t.Fatalf("error inserting: %v", err)
 		}
 
@@ -1341,7 +1341,7 @@ func TestRustBanderwagonBlock48(t *testing.T) {
 	// Insert the code chunk that isn't part of the proof
 	missingKey, _ := hex.DecodeString("744f493648c83c5ede1726a0cfbe36d3830fd5b64a820b79ca77fe159335268a")
 	missingVal, _ := hex.DecodeString("133b991f93d230604b1b8daaef64766264736f6c634300080700330000000000")
-	if err := tree.Insert(missingKey, missingVal, nil); err != nil {
+	if err := tree.Insert(missingKey, missingVal, 0, nil); err != nil {
 		t.Fatalf("error inserting: %v", err)
 	}
 
@@ -1403,7 +1403,7 @@ func BenchmarkEmptyHashCodeCachedPoint(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_, _ = NewLeafNode(zeroKeyTest, values)
+				_, _ = NewLeafNode(zeroKeyTest, values, 0)
 			}
 		})
 	}
@@ -1421,7 +1421,7 @@ func TestEmptyHashCodeCachedPoint(t *testing.T) {
 	}
 	values := make([][]byte, NodeWidth)
 	values[CodeHashVectorPosition] = emptyHashCode
-	ln, _ := NewLeafNode(zeroKeyTest, values)
+	ln, _ := NewLeafNode(zeroKeyTest, values, 0)
 
 	// Compare the result (which used the cached point) with the expected result which was
 	// calculated by a previous version of the library that didn't use a cached point.
@@ -1459,7 +1459,7 @@ func TestBatchMigratedKeyValues(t *testing.T) {
 
 					now := time.Now()
 					for _, kv := range randomKeyValues {
-						if err := tree.Insert(kv.key, kv.value, nil); err != nil {
+						if err := tree.Insert(kv.key, kv.value, 0, nil); err != nil {
 							t.Fatalf("failed to insert key: %v", err)
 						}
 					}
@@ -1497,16 +1497,16 @@ func TestBatchMigratedKeyValues(t *testing.T) {
 					nodeValues = append(nodeValues, curr)
 
 					// Create all leaves in batch mode so we can optimize cryptography operations.
-					newLeaves, err := BatchNewLeafNode(nodeValues)
+					newLeaves, err := BatchNewLeafNode(nodeValues, 0)
 					if err != nil {
 						t.Fatalf("failed to create leaves: %v", err)
 					}
 
-					if err := tree.(*InternalNode).InsertMigratedLeaves(newLeaves, nil); err != nil {
+					if err := tree.(*InternalNode).InsertMigratedLeaves(newLeaves, 0, nil); err != nil {
 						t.Fatalf("failed to insert key: %v", err)
 					}
 
-					if err = tree.(*InternalNode).InsertMigratedLeaves(newLeaves, nil); err != nil {
+					if err = tree.(*InternalNode).InsertMigratedLeaves(newLeaves, 0, nil); err != nil {
 						t.Fatalf("failed to insert key: %v", err)
 					}
 					batchedRoot := tree.Commit().Bytes()
@@ -1529,7 +1529,7 @@ func TestBatchMigratedKeyValues(t *testing.T) {
 func genRandomTree(rand *mRandV1.Rand, keyValueCount int) VerkleNode {
 	tree := New()
 	for _, kv := range genRandomKeyValues(rand, keyValueCount) {
-		if err := tree.Insert(kv.key, kv.value, nil); err != nil {
+		if err := tree.Insert(kv.key, kv.value, 0, nil); err != nil {
 			panic(fmt.Sprintf("failed to insert key: %v", err))
 		}
 	}
@@ -1562,7 +1562,7 @@ func BenchmarkBatchLeavesInsert(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
-		rand := mRandV1.New(mRandV1.NewSource(42)) //skipcq: GSC-G404
+		rand := mRandV1.New(mRandV1.NewSource(42)) // skipcq: GSC-G404
 		tree := genRandomTree(rand, treeInitialKeyValCount)
 		randomKeyValues := genRandomKeyValues(rand, migrationKeyValueCount)
 		b.StartTimer()
@@ -1589,11 +1589,11 @@ func BenchmarkBatchLeavesInsert(b *testing.B) {
 		nodeValues = append(nodeValues, curr)
 
 		// Create all leaves in batch mode so we can optimize cryptography operations.
-		newLeaves, err := BatchNewLeafNode(nodeValues)
+		newLeaves, err := BatchNewLeafNode(nodeValues, 0)
 		if err != nil {
 			b.Fatalf("failed to batch-create leaf node: %v", err)
 		}
-		if err := tree.(*InternalNode).InsertMigratedLeaves(newLeaves, nil); err != nil {
+		if err := tree.(*InternalNode).InsertMigratedLeaves(newLeaves, 0, nil); err != nil {
 			b.Fatalf("failed to insert key: %v", err)
 		}
 
@@ -1607,7 +1607,7 @@ func TestManipulateChildren(t *testing.T) {
 	t.Parallel()
 
 	root := New()
-	if err := root.Insert(ffx32KeyTest, testValue, nil); err != nil {
+	if err := root.Insert(ffx32KeyTest, testValue, 0, nil); err != nil {
 		t.Fatalf("failed to insert key: %v", err)
 	}
 
@@ -1642,7 +1642,7 @@ func TestLeafNodeInsert(t *testing.T) {
 	values := make([][]byte, NodeWidth)
 	valIdx := 42
 	values[valIdx] = testValue
-	ln, err := NewLeafNode(KeyToStem(keyTest), values)
+	ln, err := NewLeafNode(KeyToStem(keyTest), values, 0)
 	if err != nil {
 		t.Fatalf("failed to create leaf node: %v", err)
 	}
@@ -1672,7 +1672,7 @@ func TestLeafNodeInsert(t *testing.T) {
 	ffx32KeyTest2 := append([]byte{}, keyTest...)
 	ffx32KeyTest2[StemSize] = 11
 	newValue := []byte("22222222222222222222222222222222")
-	if err := ln.Insert(ffx32KeyTest2, newValue, nil); err != nil {
+	if err := ln.Insert(ffx32KeyTest2, newValue, 0, nil); err != nil {
 		t.Fatalf("failed to insert leaf node key/value: %v", err)
 	}
 	if !bytes.Equal(ln.values[valIdx], testValue) {
@@ -1683,7 +1683,7 @@ func TestLeafNodeInsert(t *testing.T) {
 	}
 
 	// Check wrong *key* length.
-	if err := ln.Insert(KeyToStem(ffx32KeyTest2), newValue, nil); err == nil {
+	if err := ln.Insert(KeyToStem(ffx32KeyTest2), newValue, 0, nil); err == nil {
 		t.Fatalf("key with size 31 should not be accepted, keys must have length StemSize+1")
 	}
 
@@ -1691,7 +1691,7 @@ func TestLeafNodeInsert(t *testing.T) {
 	ffx32KeyTest3 := append([]byte{}, keyTest...)
 	ffx32KeyTest3[StemSize] = 11
 	ffx32KeyTest3[StemSize-5] = 99
-	if err := ln.Insert(ffx32KeyTest3, newValue, nil); err == nil {
+	if err := ln.Insert(ffx32KeyTest3, newValue, 0, nil); err == nil {
 		t.Fatalf("inserting a key with a different stem should fail")
 	}
 
@@ -1723,7 +1723,7 @@ const (
 // Generate implements the quick.Generator interface from testing/quick
 // to generate random test cases.
 func (randTest) Generate(r *mRandV1.Rand, size int) reflect.Value {
-	var finishedFn = func() bool {
+	finishedFn := func() bool {
 		if size == 0 {
 			return true
 		}
@@ -1735,7 +1735,7 @@ func (randTest) Generate(r *mRandV1.Rand, size int) reflect.Value {
 
 func generateSteps(finished func() bool, r io.Reader) randTest {
 	var allKeys [][]byte
-	var tmp = []byte{0}
+	tmp := []byte{0}
 	genKey := func() []byte {
 		_, err := r.Read(tmp)
 		if err != nil {
@@ -1798,13 +1798,13 @@ func runRandTest(rt randTest) error {
 	for i, step := range rt {
 		switch step.op {
 		case opInsert:
-			if err := root.Insert(step.key, step.value, nil); err != nil {
+			if err := root.Insert(step.key, step.value, 0, nil); err != nil {
 				rt[i].err = err
 			}
 			keys = append(keys, step.key)
 			values[string(step.key)] = string(step.value)
 		case opDelete:
-			if _, err := root.Delete(step.key, nil); err != nil {
+			if _, err := root.Delete(step.key, 0, nil); err != nil {
 				rt[i].err = err
 			}
 			delete(values, string(step.key))
@@ -1862,13 +1862,13 @@ func TestRandomExtracted(t *testing.T) {
 
 	root := New()
 
-	if err := root.Insert(k1490, val_k1490_0, nil); err != nil {
+	if err := root.Insert(k1490, val_k1490_0, 0, nil); err != nil {
 		t.Fatalf("error inserting key: %v", err)
 	}
-	if err := root.Insert(k1413, val_k1413_0, nil); err != nil {
+	if err := root.Insert(k1413, val_k1413_0, 0, nil); err != nil {
 		t.Fatalf("error inserting key: %v", err)
 	}
-	if _, err := root.Delete(k1413, nil); err != nil {
+	if _, err := root.Delete(k1413, 0, nil); err != nil {
 		t.Fatalf("error deleting key: %v", err)
 	}
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -140,7 +140,7 @@ func TestGetTwoLeaves(t *testing.T) {
 		t.Fatalf("error inserting: %v", err)
 	}
 
-	val, err := root.Get(zeroKeyTest, nil)
+	val, err := root.Get(zeroKeyTest, 0, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -149,7 +149,7 @@ func TestGetTwoLeaves(t *testing.T) {
 		t.Fatalf("got a different value from the tree than expected %x != %x", val, testValue)
 	}
 
-	val, err = root.Get(oneKeyTest, nil)
+	val, err = root.Get(oneKeyTest, 0, nil)
 	if err != nil {
 		t.Fatalf("wrong error type, expected %v, got %v", nil, err)
 	}
@@ -327,7 +327,7 @@ func TestDelLeaf(t *testing.T) { // skipcq: GO-R1005
 		t.Errorf("deleting leaf resulted in unexpected tree %x %x", init.Bytes(), postHash.Bytes())
 	}
 
-	res, err := tree.Get(key3, nil)
+	res, err := tree.Get(key3, 0, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -338,7 +338,7 @@ func TestDelLeaf(t *testing.T) { // skipcq: GO-R1005
 	if _, err := tree.Delete(key1pp, 0, nil); err != nil {
 		t.Fatal(err)
 	}
-	res, err = tree.Get(key1pp, nil)
+	res, err = tree.Get(key1pp, 0, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -349,7 +349,7 @@ func TestDelLeaf(t *testing.T) { // skipcq: GO-R1005
 	if _, err := tree.Delete(key1p, 0, nil); err != nil {
 		t.Fatal(err)
 	}
-	res, err = tree.Get(key1p, nil)
+	res, err = tree.Get(key1p, 0, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -385,14 +385,14 @@ func TestDeleteAtStem(t *testing.T) {
 		t.Error(err)
 	}
 
-	res, err := tree.Get(key1, nil)
+	res, err := tree.Get(key1, 0, nil)
 	if err != nil {
 		t.Error(err)
 	}
 	if len(res) > 0 {
 		t.Error("leaf hasnt been deleted")
 	}
-	res, err = tree.Get(key1pp, nil)
+	res, err = tree.Get(key1pp, 0, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -467,7 +467,7 @@ func TestDeletePrune(t *testing.T) { // skipcq: GO-R1005
 	if !hashPostKey4.Equal(postHash) {
 		t.Error("deleting leaf #5 resulted in unexpected tree")
 	}
-	res, err := tree.Get(key5, nil)
+	res, err := tree.Get(key5, 0, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -487,7 +487,7 @@ func TestDeletePrune(t *testing.T) { // skipcq: GO-R1005
 	if !hashPostKey2.Equal(postHash) {
 		t.Error("deleting leaf #3 resulted in unexpected tree")
 	}
-	res, err = tree.Get(key3, nil)
+	res, err = tree.Get(key3, 0, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -884,17 +884,17 @@ func TestGetResolveFromHash(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	data, err := root.Get(zeroKeyTest, nil)
+	data, err := root.Get(zeroKeyTest, 0, nil)
 	if !errors.Is(err, errReadFromInvalid) || len(data) != 0 {
 		t.Fatal(err)
 	}
 
-	data, err = root.Get(zeroKeyTest, failingGetter)
+	data, err = root.Get(zeroKeyTest, 0, failingGetter)
 	if !errors.Is(err, dummyError) || len(data) != 0 {
 		t.Fatal(err)
 	}
 
-	data, err = root.Get(zeroKeyTest, getter)
+	data, err = root.Get(zeroKeyTest, 0, getter)
 	if err != nil {
 		t.Fatalf("error resolving hash: %v", err)
 	}
@@ -1648,7 +1648,7 @@ func TestLeafNodeInsert(t *testing.T) {
 	}
 
 	// Check we get the value correctly via Get(...).
-	getValue, err := ln.Get(append(KeyToStem(keyTest), byte(valIdx)), nil)
+	getValue, err := ln.Get(append(KeyToStem(keyTest), byte(valIdx)), 0, nil)
 	if err != nil {
 		t.Fatalf("failed to get leaf node key/value: %v", err)
 	}
@@ -1809,7 +1809,7 @@ func runRandTest(rt randTest) error {
 			}
 			delete(values, string(step.key))
 		case opGet:
-			v, err := root.Get(step.key, nil)
+			v, err := root.Get(step.key, 0, nil)
 			want := values[string(step.key)]
 			if string(v) != want {
 				rt[i].err = fmt.Errorf("mismatch for key %#x, got %#x want %#x, err %v", step.key, v, want, err)
@@ -1872,7 +1872,7 @@ func TestRandomExtracted(t *testing.T) {
 		t.Fatalf("error deleting key: %v", err)
 	}
 
-	val, err := root.Get(k1490, nil)
+	val, err := root.Get(k1490, 0, nil)
 	if err != nil {
 		t.Fatalf("error getting key: %v", err)
 	}

--- a/unknown.go
+++ b/unknown.go
@@ -29,11 +29,11 @@ import "errors"
 
 type UnknownNode struct{}
 
-func (UnknownNode) Insert([]byte, []byte, NodeResolverFn) error {
+func (UnknownNode) Insert([]byte, []byte, StateEpoch, NodeResolverFn) error {
 	return errMissingNodeInStateless
 }
 
-func (UnknownNode) Delete([]byte, NodeResolverFn) (bool, error) {
+func (UnknownNode) Delete([]byte, StateEpoch, NodeResolverFn) (bool, error) {
 	return false, errors.New("cant delete in a subtree missing form a stateless view")
 }
 

--- a/unknown.go
+++ b/unknown.go
@@ -37,7 +37,7 @@ func (UnknownNode) Delete([]byte, StateEpoch, NodeResolverFn) (bool, error) {
 	return false, errors.New("cant delete in a subtree missing form a stateless view")
 }
 
-func (UnknownNode) Get([]byte, NodeResolverFn) ([]byte, error) {
+func (UnknownNode) Get([]byte, StateEpoch, NodeResolverFn) ([]byte, error) {
 	return nil, nil
 }
 

--- a/unknown_test.go
+++ b/unknown_test.go
@@ -13,7 +13,7 @@ func TestUnknownFuncs(t *testing.T) {
 	if _, err := un.Delete(nil, 0, nil); err == nil {
 		t.Errorf("got nil error when deleting from a hashed node")
 	}
-	if _, err := un.Get(nil, nil); err != nil {
+	if _, err := un.Get(nil, 0, nil); err != nil {
 		t.Errorf("got %v, want nil", err)
 	}
 	var identity Point

--- a/unknown_test.go
+++ b/unknown_test.go
@@ -7,10 +7,10 @@ func TestUnknownFuncs(t *testing.T) {
 
 	un := UnknownNode{}
 
-	if err := un.Insert(nil, nil, nil); err != errMissingNodeInStateless {
+	if err := un.Insert(nil, nil, 0, nil); err != errMissingNodeInStateless {
 		t.Errorf("got %v, want %v", err, errMissingNodeInStateless)
 	}
-	if _, err := un.Delete(nil, nil); err == nil {
+	if _, err := un.Delete(nil, 0, nil); err == nil {
 		t.Errorf("got nil error when deleting from a hashed node")
 	}
 	if _, err := un.Get(nil, nil); err != nil {


### PR DESCRIPTION
Primary changes:
- Add new `StateEpoch` type
- Modify `Get`, `Insert` and `Delete` to include `StateEpoch`. If trying to access expired leaf node, returns error.
- Additional `lastEpoch` field in `LeafNode`, included in serialization and node commitment calculation
- Add new `ExpiryLeafNode` struct