### PR TITLE
add proof Equal methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 
 > A Go implementation of Verkle Tree datastructure defined in the [spec](https://github.com/crate-crypto/verkle-trie-ref/tree/master/verkle). 
 
-
 ## Test & Benchmarks
 
 To run the tests and benchmarks, run the following commands:

--- a/proof_ipa.go
+++ b/proof_ipa.go
@@ -53,6 +53,9 @@ type VerkleProof struct {
 }
 
 func (vp *VerkleProof) Copy() *VerkleProof {
+	if vp == nil {
+		return nil
+	}
 	ret := &VerkleProof{
 		OtherStems:            make([][StemSize]byte, len(vp.OtherStems)),
 		DepthExtensionPresent: make([]byte, len(vp.DepthExtensionPresent)),

--- a/proof_ipa.go
+++ b/proof_ipa.go
@@ -73,6 +73,35 @@ func (vp *VerkleProof) Copy() *VerkleProof {
 	return ret
 }
 
+func (vp *VerkleProof) Equal(other *VerkleProof) error {
+	if len(vp.OtherStems) != len(other.OtherStems) {
+		return fmt.Errorf("different number of other stems: %d != %d", len(vp.OtherStems), len(other.OtherStems))
+	}
+	for i := range vp.OtherStems {
+		if vp.OtherStems[i] != other.OtherStems[i] {
+			return fmt.Errorf("different other stem: %x != %x", vp.OtherStems[i], other.OtherStems[i])
+		}
+	}
+	if len(vp.DepthExtensionPresent) != len(other.DepthExtensionPresent) {
+		return fmt.Errorf("different number of depth extension present: %d != %d", len(vp.DepthExtensionPresent), len(other.DepthExtensionPresent))
+	}
+	if !bytes.Equal(vp.DepthExtensionPresent, other.DepthExtensionPresent) {
+		return fmt.Errorf("different depth extension present: %x != %x", vp.DepthExtensionPresent, other.DepthExtensionPresent)
+	}
+	if len(vp.CommitmentsByPath) != len(other.CommitmentsByPath) {
+		return fmt.Errorf("different number of commitments by path: %d != %d", len(vp.CommitmentsByPath), len(other.CommitmentsByPath))
+	}
+	for i := range vp.CommitmentsByPath {
+		if vp.CommitmentsByPath[i] != other.CommitmentsByPath[i] {
+			return fmt.Errorf("different commitment by path: %x != %x", vp.CommitmentsByPath[i], other.CommitmentsByPath[i])
+		}
+	}
+	if vp.D != other.D {
+		return fmt.Errorf("different D: %x != %x", vp.D, other.D)
+	}
+	return nil
+}
+
 type Proof struct {
 	Multipoint *ipa.MultiProof // multipoint argument
 	ExtStatus  []byte          // the extension status of each stem
@@ -116,6 +145,40 @@ func (sd StateDiff) Copy() StateDiff {
 		}
 	}
 	return ret
+}
+
+func (sd StateDiff) Equal(other StateDiff) error {
+	if len(sd) != len(other) {
+		return fmt.Errorf("different number of stem state diffs: %d != %d", len(sd), len(other))
+	}
+	for i := range sd {
+		if sd[i].Stem != other[i].Stem {
+			return fmt.Errorf("different stem: %x != %x", sd[i].Stem, other[i].Stem)
+		}
+		if len(sd[i].SuffixDiffs) != len(other[i].SuffixDiffs) {
+			return fmt.Errorf("different number of suffix state diffs: %d != %d", len(sd[i].SuffixDiffs), len(other[i].SuffixDiffs))
+		}
+		for j := range sd[i].SuffixDiffs {
+			if sd[i].SuffixDiffs[j].Suffix != other[i].SuffixDiffs[j].Suffix {
+				return fmt.Errorf("different suffix: %x != %x", sd[i].SuffixDiffs[j].Suffix, other[i].SuffixDiffs[j].Suffix)
+			}
+			if sd[i].SuffixDiffs[j].CurrentValue != nil && other[i].SuffixDiffs[j].CurrentValue != nil {
+				if *sd[i].SuffixDiffs[j].CurrentValue != *other[i].SuffixDiffs[j].CurrentValue {
+					return fmt.Errorf("different current value: %x != %x", *sd[i].SuffixDiffs[j].CurrentValue, *other[i].SuffixDiffs[j].CurrentValue)
+				}
+			} else if sd[i].SuffixDiffs[j].CurrentValue != nil || other[i].SuffixDiffs[j].CurrentValue != nil {
+				return fmt.Errorf("different current value: %x != %x", sd[i].SuffixDiffs[j].CurrentValue, other[i].SuffixDiffs[j].CurrentValue)
+			}
+			if sd[i].SuffixDiffs[j].NewValue != nil && other[i].SuffixDiffs[j].NewValue != nil {
+				if *sd[i].SuffixDiffs[j].NewValue != *other[i].SuffixDiffs[j].NewValue {
+					return fmt.Errorf("different new value: %x != %x", *sd[i].SuffixDiffs[j].NewValue, *other[i].SuffixDiffs[j].NewValue)
+				}
+			} else if sd[i].SuffixDiffs[j].NewValue != nil || other[i].SuffixDiffs[j].NewValue != nil {
+				return fmt.Errorf("different new value: %x != %x", sd[i].SuffixDiffs[j].NewValue, other[i].SuffixDiffs[j].NewValue)
+			}
+		}
+	}
+	return nil
 }
 
 func GetCommitmentsForMultiproof(root VerkleNode, keys [][]byte, resolver NodeResolverFn) (*ProofElements, []byte, []Stem, error) {

--- a/proof_json.go
+++ b/proof_json.go
@@ -42,6 +42,10 @@ func PrefixedHexStringToBytes(input string) ([]byte, error) {
 	if input[0:2] == "0x" {
 		input = input[2:]
 	}
+	// TODO(jsign): workaround for execution-spec-tests bug. Remove as soon as it's fixed.
+	if len(input)%2 != 0 {
+		input = "0" + input
+	}
 	return hex.DecodeString(input)
 }
 

--- a/proof_json.go
+++ b/proof_json.go
@@ -42,10 +42,6 @@ func PrefixedHexStringToBytes(input string) ([]byte, error) {
 	if input[0:2] == "0x" {
 		input = input[2:]
 	}
-	// TODO(jsign): workaround for execution-spec-tests bug. Remove as soon as it's fixed.
-	if len(input)%2 != 0 {
-		input = "0" + input
-	}
 	return hex.DecodeString(input)
 }
 


### PR DESCRIPTION
This PR adds `.Equal` methods to proof fields so clients can compare re-generated proofs against block proofs.

This is required for https://github.com/gballet/go-ethereum/pull/515