### PR TITLE
fix: EoA pattern recognition

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -1861,8 +1861,8 @@ func (n *LeafNode) serializeLeafWithUncompressedCommitments(cBytes, c1Bytes, c2B
 		if isEoA {
 			switch i {
 			case 0:
-				// Version should be 0
-				isEoA = v != nil
+				// Version + reserved fields + code size should be 0
+				isEoA = v != nil && bytes.Equal(v[0:8], zero32[0:8])
 			case 1:
 				// Code hash should be the empty code hash
 				isEoA = v != nil && bytes.Equal(v, EmptyCodeHash[:])


### PR DESCRIPTION
I realized that the "EoA pattern recognition" had been re-enabled, and that the test fix I pushed in `master` was actually the wrong fix.

The reason for the tests failing, is that the leaf pattern hasn't been changed to "Nyota" in that test, while the encoding code did. So I updated the test to make sure that it was testing the right pattern.

There is another issue: no check was made to ensure that the version were 0. Which means that any `LeafNode` that had only slot 0 and 1 set, with slot 1 being the `EmptyHash`, would be considered an EoA and encoded as such... but if `version`, `code size` and the reserved space was non-zero, it would not be saved while being serialized! This is a very rare occurrence, but definitely a bug.