### PR TITLE
Set Cn to identity instead of nil, when deleting a 128-leaf subtree

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -1384,9 +1384,9 @@ func (n *LeafNode) Delete(k []byte, _ NodeResolverFn) (bool, error) {
 
 		// Clear the corresponding commitment
 		if k[StemSize] < 128 {
-			n.c1 = nil
+			n.c1 = new(Point).SetIdentity()
 		} else {
-			n.c2 = nil
+			n.c2 = new(Point).SetIdentity()
 		}
 
 		return false, nil


### PR DESCRIPTION
Even though verkle doesn't support deletions during transaction execution (yet) we have to support deletions so that geth can rollback state during a reorg.

When either the left or right suffix subtree of a `LeafNode` becomes empty, the commitment must be set to 0. It used to be set to `nil`, but this would cause panics later down the line when inserting value and trying to differentially-update the commitment.

I can foresee that this will cause an issue for storage size, as we'd potentially be storing a 0. But this will unblock Gary for his rollback experiments.